### PR TITLE
Simulation from the original VATA library

### DIFF
--- a/include/vata2/explicit_lts.hh
+++ b/include/vata2/explicit_lts.hh
@@ -38,7 +38,7 @@ public:
 	 *
 	 * @param[in]  states  The least number of states to consider
 	 */
-	ExplicitLTS(size_t states = 0) :
+	explicit ExplicitLTS(size_t states = 0) :
             states_(states),
             transitions_(0),
             data_(),

--- a/include/vata2/explicit_lts.hh
+++ b/include/vata2/explicit_lts.hh
@@ -1,0 +1,142 @@
+/*****************************************************************************
+ *  VATA Tree Automata Library
+ *
+ *  Copyright (c) 2011  Jiri Simacek <isimacek@fit.vutbr.cz>
+ *
+ *  Description:
+ *    Header file for LTS class definition.
+ *
+ *****************************************************************************/
+
+#ifndef _VATA2_EXPLICIT_LTS_HH_
+#define _VATA2_EXPLICIT_LTS_HH_
+
+#include <vector>
+
+#include <vata2/simutil/binary_relation.hh>
+#include <vata2/simutil/smart_set.hh>
+
+
+namespace Vata2 { class ExplicitLTS; }
+
+class Vata2::ExplicitLTS {
+
+	size_t states_;
+	size_t transitions_;
+	std::vector<
+		std::pair<
+			std::vector<std::vector<size_t>>,
+			std::vector<std::vector<size_t>>
+		>
+	> data_;
+	std::vector<Util::SmartSet> bwLabels_;
+
+public:
+
+	/**
+	 * @brief  The constructor
+	 *
+	 * @param[in]  states  The least number of states to consider
+	 */
+	ExplicitLTS(size_t states = 0) :
+		states_(states),
+		transitions_(0),
+		data_(),
+		bwLabels_()
+	{ }
+
+	void add_transition(size_t q, size_t a, size_t r);
+
+	void init()
+	{
+		this->bwLabels_.resize(this->states_, Util::SmartSet(this->data_.size()));
+
+		for (size_t a = 0; a < this->data_.size(); ++a)
+		{
+			this->data_[a].first.resize(this->states_);
+			this->data_[a].second.resize(this->states_);
+
+			for (size_t r = 0; r < this->states_; ++r)
+			{
+				this->bwLabels_[r].init(a, this->data_[a].second[r].size());
+			}
+		}
+	}
+
+	void clear()
+	{
+		this->data_.clear();
+		this->bwLabels_.clear();
+		this->states_ = 0;
+		this->transitions_ = 0;
+	}
+
+	const std::vector<std::vector<size_t>>& post(size_t a) const
+	{
+		assert(a < this->data_.size());
+
+		return this->data_[a].first;
+	}
+
+	const std::vector<std::vector<size_t>>& pre(size_t a) const
+	{
+		assert(a < this->data_.size());
+
+		return this->data_[a].second;
+	}
+
+	const Util::SmartSet& bwLabels(size_t q) const
+	{
+		assert(q < this->bwLabels_.size());
+
+		return this->bwLabels_[q];
+	}
+
+	void buildDelta1(std::vector<Util::SmartSet>& delta1) const
+	{
+		delta1.resize(this->data_.size(), Util::SmartSet(this->states_));
+
+		for (size_t a = 0; a < this->data_.size(); ++a)
+		{
+			for (size_t q = 0; q < this->data_[a].first.size(); ++q)
+			{
+				delta1[a].init(q, delta1[a].count(q) + this->data_[a].first[q].size());
+			}
+		}
+	}
+
+	size_t labels() const { return this->data_.size(); }
+
+	const size_t& states() const { return this->states_; }
+
+	friend std::ostream& operator<<(std::ostream& os, const ExplicitLTS& lts)
+	{
+		for (size_t a = 0; a < lts.data_.size(); ++a)
+		{
+			for (size_t q = 0; q < lts.data_[a].second.size(); ++q)
+			{
+				for (auto& r : lts.data_[a].first[q])
+				{
+					os << q << " --" << a << "--> " << r << std::endl;
+				}
+			}
+		}
+
+		return os;
+	}
+
+public:
+
+	Util::BinaryRelation computeSimulation(
+		const std::vector<std::vector<size_t>>&   partition,
+		const Util::BinaryRelation&               relation,
+		size_t                                    outputSize
+	);
+
+	Util::BinaryRelation computeSimulation(
+		size_t   outputSize);
+
+	Util::BinaryRelation computeSimulation();
+};
+
+#endif

--- a/include/vata2/explicit_lts.hh
+++ b/include/vata2/explicit_lts.hh
@@ -29,7 +29,7 @@ class Vata2::ExplicitLTS {
 			std::vector<std::vector<size_t>>
 		>
 	> data_;
-	std::vector<Util::SmartSet> bwLabels_;
+	std::vector<Util::SmartSet> bw_labels_;
 
 public:
 
@@ -39,17 +39,17 @@ public:
 	 * @param[in]  states  The least number of states to consider
 	 */
 	ExplicitLTS(size_t states = 0) :
-		states_(states),
-		transitions_(0),
-		data_(),
-		bwLabels_()
+            states_(states),
+            transitions_(0),
+            data_(),
+            bw_labels_()
 	{ }
 
 	void add_transition(size_t q, size_t a, size_t r);
 
 	void init()
 	{
-		this->bwLabels_.resize(this->states_, Util::SmartSet(this->data_.size()));
+		this->bw_labels_.resize(this->states_, Util::SmartSet(this->data_.size()));
 
 		for (size_t a = 0; a < this->data_.size(); ++a)
 		{
@@ -58,7 +58,7 @@ public:
 
 			for (size_t r = 0; r < this->states_; ++r)
 			{
-				this->bwLabels_[r].init(a, this->data_[a].second[r].size());
+				this->bw_labels_[r].init(a, this->data_[a].second[r].size());
 			}
 		}
 	}
@@ -66,7 +66,7 @@ public:
 	void clear()
 	{
 		this->data_.clear();
-		this->bwLabels_.clear();
+		this->bw_labels_.clear();
 		this->states_ = 0;
 		this->transitions_ = 0;
 	}
@@ -85,14 +85,14 @@ public:
 		return this->data_[a].second;
 	}
 
-	const Util::SmartSet& bwLabels(size_t q) const
+	const Util::SmartSet& bw_labels(size_t q) const
 	{
-		assert(q < this->bwLabels_.size());
+		assert(q < this->bw_labels_.size());
 
-		return this->bwLabels_[q];
+		return this->bw_labels_[q];
 	}
 
-	void buildDelta1(std::vector<Util::SmartSet>& delta1) const
+	void build_delta1(std::vector<Util::SmartSet>& delta1) const
 	{
 		delta1.resize(this->data_.size(), Util::SmartSet(this->states_));
 
@@ -127,16 +127,16 @@ public:
 
 public:
 
-	Util::BinaryRelation computeSimulation(
+	Util::BinaryRelation compute_simulation(
 		const std::vector<std::vector<size_t>>&   partition,
 		const Util::BinaryRelation&               relation,
 		size_t                                    outputSize
 	);
 
-	Util::BinaryRelation computeSimulation(
+	Util::BinaryRelation compute_simulation(
 		size_t   outputSize);
 
-	Util::BinaryRelation computeSimulation();
+	Util::BinaryRelation compute_simulation();
 };
 
 #endif

--- a/include/vata2/nfa.hh
+++ b/include/vata2/nfa.hh
@@ -31,6 +31,7 @@
 #include <vata2/parser.hh>
 #include <vata2/util.hh>
 #include <vata2/ord_vector.hh>
+#include <vata2/explicit_lts.hh>
 
 namespace Vata2
 {
@@ -547,7 +548,8 @@ inline Nfa invert(const Nfa &aut)
     invert(&inverted, aut);
     return inverted;
 }
-// TODO: VATA::Util::BinaryRelation computeSimulation() const;
+
+Vata2::Util::BinaryRelation compute_simulation(const Nfa& aut);
 
 /// Is the language of the automaton universal?
 bool is_universal(

--- a/include/vata2/nfa.hh
+++ b/include/vata2/nfa.hh
@@ -549,7 +549,9 @@ inline Nfa invert(const Nfa &aut)
     return inverted;
 }
 
-Vata2::Util::BinaryRelation compute_simulation(const Nfa& aut);
+Vata2::Util::BinaryRelation compute_relation(
+        const Nfa& aut,
+        const StringDict&  params = {{"relation", "simulation"}});
 
 /// Is the language of the automaton universal?
 bool is_universal(

--- a/include/vata2/nfa.hh
+++ b/include/vata2/nfa.hh
@@ -551,7 +551,7 @@ inline Nfa invert(const Nfa &aut)
 
 Vata2::Util::BinaryRelation compute_relation(
         const Nfa& aut,
-        const StringDict&  params = {{"relation", "simulation"}});
+        const StringDict&  params = {{"relation", "simulation"}, {"direction","forward"}});
 
 /// Is the language of the automaton universal?
 bool is_universal(

--- a/include/vata2/nfa.hh
+++ b/include/vata2/nfa.hh
@@ -31,7 +31,7 @@
 #include <vata2/parser.hh>
 #include <vata2/util.hh>
 #include <vata2/ord_vector.hh>
-#include <vata2/explicit_lts.hh>
+#include <vata2/simutil/binary_relation.hh>
 
 namespace Vata2
 {

--- a/include/vata2/ord_vector.hh
+++ b/include/vata2/ord_vector.hh
@@ -426,7 +426,7 @@ public:   // Public methods
 	 *
 	 * Overloaded << operator for output stream.
 	 *
-	 * @see  ToString()
+	 * @see  to_string()
 	 *
 	 * @param[in]  os    The output stream
 	 * @param[in]  vec   Assignment to the variables

--- a/include/vata2/simutil/abstract_transl.hh
+++ b/include/vata2/simutil/abstract_transl.hh
@@ -39,8 +39,7 @@ namespace Vata2
 				return this->operator()(value);
 			}
 
-			virtual ~AbstractTranslator()
-			{ }
+			virtual ~AbstractTranslator() = default;
 		};
 	}
 }

--- a/include/vata2/simutil/abstract_transl.hh
+++ b/include/vata2/simutil/abstract_transl.hh
@@ -1,0 +1,48 @@
+/*****************************************************************************
+ *  VATA Tree Automata Library
+ *
+ *  Copyright (c) 2011  Ondra Lengal <ilengal@fit.vutbr.cz>
+ *
+ *  Description:
+ *    The header file of the abstract translator class.
+ *
+ *****************************************************************************/
+
+#ifndef _VATA2_ABSTRACT_TRANSL_HH_
+#define _VATA2_ABSTRACT_TRANSL_HH_
+
+namespace Vata2
+{
+	namespace Util
+	{
+		template <
+			class FromT,
+			class ToT>
+		class AbstractTranslator
+		{
+		public:  // methods
+			virtual ToT operator()(const FromT& value) = 0;
+			virtual ToT operator()(const FromT& value) const = 0;
+
+			ToT at(const FromT& value) const
+			{
+				return this->operator()(value);
+			}
+
+			ToT at(const FromT& value)
+			{
+				return this->operator()(value);
+			}
+
+			ToT operator[](const FromT& value)
+			{
+				return this->operator()(value);
+			}
+
+			virtual ~AbstractTranslator()
+			{ }
+		};
+	}
+}
+
+#endif

--- a/include/vata2/simutil/binary_relation.hh
+++ b/include/vata2/simutil/binary_relation.hh
@@ -74,18 +74,7 @@ protected:
 		this->realloc(newRowSize, defVal);
 
 	}
-/*
-	void shrinkToFit() {
 
-		assert(this->row_size_ > this->size_);
-		size_t newRowSize = this->row_size_;
-		while (this->size_ < (newRowSize >> 1))
-			newRowSize >>= 1;
-		assert(this->size_ <= newRowSize);
-		this->realloc(newRowSize);
-
-	}
-*/
 public:
 
 	void reset(bool defVal)
@@ -182,11 +171,6 @@ public:
 	{
 		this->resize(size, defVal);
 	}
-
-/*
-	BinaryRelation(const BinaryRelation& rel)
-		: data_(rel.data_), row_size_(rel.row_size_), size_(rel.size_) {}
-*/
 
 	BinaryRelation(const std::vector<std::vector<bool> >& rel) :
 		data_(16*16, false),

--- a/include/vata2/simutil/binary_relation.hh
+++ b/include/vata2/simutil/binary_relation.hh
@@ -1,0 +1,935 @@
+/*****************************************************************************
+ *  VATA Tree Automata Library
+ *
+ *  Copyright (c) 2011  Jiri Simacek <isimacek@fit.vutbr.cz>
+ *
+ *  Description:
+ *    Binary relation class.
+ *
+ *****************************************************************************/
+
+#ifndef _VATA2_BINARY_RELATION_HH_
+#define _VATA2_BINARY_RELATION_HH_
+
+// VATA headers
+#include <vata2/convert.hh>
+#include <vata2/simutil/vata.hh>
+#include <vata2/simutil/transl_weak.hh>
+#include <vata2/simutil/two_way_dict.hh>
+
+// Standard library headers
+#include <vector>
+#include <algorithm>
+#include <unordered_map>
+
+namespace Vata2
+{
+	namespace Util
+	{
+		class BinaryRelation;
+		class Identity;
+		class DiscontBinaryRelation;
+	}
+}
+
+
+/**
+ * @brief  A binary relation address continuously
+ *
+ * A binary relation addressed from indices from 0 to @p size_ - 1
+ */
+class Vata2::Util::BinaryRelation
+{
+	std::vector<bool> data_;
+	size_t rowSize_;
+	size_t size_;
+
+protected:
+
+	void realloc(size_t newRowSize, bool defVal)
+	{
+		// check for sane parameters
+		assert(0 < newRowSize);
+
+		std::vector<bool> tmp(newRowSize*newRowSize, defVal);
+		std::vector<bool>::const_iterator src = data_.begin();
+		std::vector<bool>::iterator dst = tmp.begin();
+		for (size_t i = 0; i < size_; ++i) {
+			std::copy(src, src + size_, dst);
+			src += rowSize_;
+			dst += newRowSize;
+		}
+		std::swap(data_, tmp);
+		rowSize_ = newRowSize;
+	}
+
+	void grow(size_t newSize, bool defVal = false)
+	{
+		assert(rowSize_ <= newSize);
+
+		size_t newRowSize = rowSize_;
+		while (newRowSize <= newSize)
+			newRowSize <<= 1;
+		assert(newSize <= newRowSize);
+		this->realloc(newRowSize, defVal);
+
+	}
+/*
+	void shrinkToFit() {
+
+		assert(this->rowSize_ > this->size_);
+		size_t newRowSize = this->rowSize_;
+		while (this->size_ < (newRowSize >> 1))
+			newRowSize >>= 1;
+		assert(this->size_ <= newRowSize);
+		this->realloc(newRowSize);
+
+	}
+*/
+public:
+
+	void reset(bool defVal)
+	{
+		std::fill(data_.begin(), data_.end(), defVal);
+	}
+
+	void resize(size_t size, bool defVal = false)
+	{
+
+		if (rowSize_ < size)
+		{
+			this->grow(size, defVal);
+		}
+
+		size_ = size;
+	}
+
+	size_t alloc()
+	{
+		if (size_ >= rowSize_)
+		{
+			this->grow(size_ + 1);
+		}
+
+		return size_++;
+	}
+
+	size_t split(size_t i, bool reflexive = true)
+	{
+		assert(i < size_);
+
+		if (size_ >= rowSize_)
+		{
+			this->grow(size_ + 1);
+		}
+
+		assert((size_ + 1)*rowSize_ <= data_.size());
+
+		// fill collumns
+		auto src = data_.begin() + i;
+		auto end = src + size_*rowSize_;
+		auto dst = data_.begin() + size_;
+
+		for ( ; src != end; src += rowSize_, dst += rowSize_)
+		{
+			*dst = *src;
+		}
+
+		// fill rows
+		src = data_.begin() + i*rowSize_;
+		dst = data_.begin() + size_*rowSize_;
+
+		std::copy(src, src + size_, dst);
+
+		// set the reflexive bit
+		*(dst + size_) = reflexive;
+
+		return size_++;
+	}
+
+	bool get(size_t r, size_t c) const
+	{
+		assert(r < size_ && c < size_);
+		assert(r*rowSize_ + c < data_.size());
+
+		return data_[r*rowSize_ + c];
+	}
+
+	void set(size_t r, size_t c, bool v)
+	{
+		assert(r < size_ && c < size_);
+		assert(r*rowSize_ + c < data_.size());
+
+		data_[r*rowSize_ + c] = v;
+	}
+
+	size_t size() const
+	{
+		return size_;
+	}
+
+public:
+
+	using IndexType    = std::vector<std::vector<size_t>>;
+
+	BinaryRelation(
+		size_t         size = 0,
+		bool           defVal = false,
+		size_t         rowSize = 16) :
+		data_(rowSize*rowSize, defVal),
+		rowSize_(rowSize),
+		size_(0)
+	{
+		this->resize(size, defVal);
+	}
+
+/*
+	BinaryRelation(const BinaryRelation& rel)
+		: data_(rel.data_), rowSize_(rel.rowSize_), size_(rel.size_) {}
+*/
+
+	BinaryRelation(const std::vector<std::vector<bool> >& rel) :
+		data_(16*16, false),
+		rowSize_(16),
+		size_(0)
+	{
+		this->resize(rel.size(), false);
+		for (size_t i = 0; i < rel.size(); ++i)
+		{
+			assert(rel[i].size() == rel.size());
+			for (size_t j = 0; j < rel.size(); ++j)
+			{
+				this->set(i, j, rel[i][j]);
+			}
+		}
+	}
+
+	// TODO: does this do what is expected? What is expected this should do???
+	// WHAT ABOUT SOME FREAKING DOCUMENTATION??????
+	bool sym(size_t row, size_t column) const
+	{
+		return this->get(row, column) && this->get(column, row);
+	}
+
+	// build equivalence classes
+	void buildClasses(std::vector<size_t>& headIndex) const
+	{
+		headIndex.resize(size_);
+		std::vector<size_t> head;
+		for (size_t i = 0; i < size_; ++i)
+		{
+			size_t j = 0;
+			while ((j < head.size()) && !this->sym(i, head[j]))
+			{
+				++j;
+			}
+
+			if (j < head.size())
+			{
+				headIndex[i] = head[j];
+			}
+			else
+			{
+				headIndex[i] = i;
+				head.push_back(i);
+			}
+		}
+	}
+
+	// build equivalence classes
+	void buildClasses(
+		std::vector<size_t>&       index,
+		std::vector<size_t>&       head) const
+	{
+		index.resize(size_);
+		head.clear();
+
+		for (size_t i = 0; i < size_; ++i)
+		{
+			size_t j = 0;
+			while ((j < head.size()) && !this->sym(i, head[j]))
+			{
+				++j;
+			}
+
+			if (j < head.size())
+			{
+				index[i] = j;
+			}
+			else
+			{
+				index[i] = head.size();
+				head.push_back(i);
+			}
+		}
+	}
+
+	// and composition
+	BinaryRelation& operator&=(const BinaryRelation& rhs)
+	{
+		assert(size_ == rhs.size_);
+
+		for (size_t i = 0; i < size_; ++i)
+		{
+			for (size_t j = 0; j < size_; ++j)
+			{
+				this->set(i, j, this->get(i, j) && rhs.get(i,j));
+			}
+		}
+
+		return *this;
+	}
+
+	// transposition
+	BinaryRelation& transposed(BinaryRelation& dst) const
+	{
+		dst.resize(size_);
+		for (size_t i = 0; i < size_; ++i)
+		{
+			for (size_t j = 0; j < size_; ++j)
+			{
+				dst.set(j, i, this->get(i, j));
+			}
+		}
+
+		return dst;
+	}
+
+
+	/**
+	 * @brief  Creates a mapping from elements to their images
+	 *
+	 * This method maps elements to their images. Formally, it creates for each
+	 * element 'x' the mapping 'x -> Y' where 'Y = {y | xRy}'
+	 *
+	 * @param[out]  dst  The result mapping every element to its images
+	 *
+	 * @see  buildInvIndex
+	 */
+	void buildIndex(IndexType& dst) const
+	{
+		dst.resize(size_);
+
+		auto rowStart = data_.begin();
+		auto src = rowStart;
+		auto end = src + size_*rowSize_;
+		auto dstIter = dst.begin();
+
+		for (; src != end; src = rowStart, ++dstIter)
+		{
+			auto rowEnd = src + size_;
+			rowStart = src + rowSize_;
+
+			for (size_t i = 0; src != rowEnd; ++src, ++i)
+			{
+				if (*src)
+				{
+					dstIter->push_back(i);
+				}
+			}
+		}
+	}
+
+	/**
+	 * @brief  Creates a mapping from elements to their co-images
+	 *
+	 * This method maps elements to their co-images. Formally, it creates for each
+	 * element 'x' the mapping 'x -> Y' where 'Y = {y | yRx}'
+	 *
+	 * @param[out]  dst  The result mapping every element to its co-images
+	 *
+	 * @see buildIndex
+	 */
+	void buildInvIndex(IndexType& dst) const
+	{
+		dst.resize(size_);
+
+		for (size_t i = 0; i < size_; ++i)
+		{
+			for (size_t j = 0; j < size_; ++j)
+			{
+				if (this->get(i, j))
+				{
+					dst[j].push_back(i);
+				}
+			}
+		}
+	}
+
+	/**
+	 * @brief  Creates a mapping from elements to their images and co-images
+	 *
+	 * This method the call to buildIndex and buildInvIndex, i.e. it maps
+	 * elements to their images (in @p ind) and their co-images (in @p inv).
+	 *
+	 * @param[out]  ind  The result mapping every element to its images
+	 * @param[out]  inv  The result mapping every element to its co-images
+	 *
+	 * @see buildIndex buildInvIndex
+	 */
+	void buildIndex(IndexType& ind, IndexType& inv) const
+	{
+		ind.resize(size_);
+		inv.resize(size_);
+
+		for (size_t i = 0; i < size_; ++i)
+		{
+			for (size_t j = 0; j < size_; ++j)
+			{
+				if (this->get(i, j))
+				{
+					ind[i].push_back(j);
+					inv[j].push_back(i);
+				}
+			}
+		}
+	}
+
+	/**
+	 * @brief  Restricts the relation to its symmetric fragment
+	 */
+	void RestrictToSymmetric()
+	{
+		for (size_t row = 0; row < this->size(); ++row)
+		{
+			for (size_t col = row + 1; col < this->size(); ++col)
+			{	// traverse the matrix (we do just the part above the diagonal)
+				bool res = this->get(row, col) && this->get(col, row);
+				this->set(row, col, res);
+				this->set(col, row, res);
+			}
+		}
+	}
+
+
+	/**
+	 * @brief  Gets the projection of elements to their representatives
+	 *
+	 * This method relies on the fact that @p *this represents an equivalance
+	 * relation (the result is undefined otherwise). The method creates the
+	 * projection of elements to their representatives in the quotient set
+	 * induced by the equivalence relation represented by @p *this.
+	 *
+	 * @param[out]  quotProj  The vector mapping elements to their
+	 *                        representatives in the quotient set, quotProj[i] is
+	 *                        the number that the i-th guy maps to
+	 */
+	void GetQuotientProjection(
+		std::vector<size_t>&             quotProj)
+	{
+		const size_t UNDEF_PROJ = static_cast<size_t>(-1);
+
+		quotProj.resize(this->size());
+		for (size_t& elem : quotProj)
+		{
+			elem = UNDEF_PROJ;
+		}
+
+		for (size_t row = 0; row < this->size(); ++row)
+		{	// traverse the matrix above the diagonal, only
+			assert(row < quotProj.size());
+			if (UNDEF_PROJ != quotProj[row])
+			{	// in the case 'row' is already in some equivalence class
+				continue;
+			}
+
+			quotProj[row] = row;
+			for (size_t col = row + 1; col < this->size(); ++col)
+			{
+				if (this->get(row, col))
+				{	// if 'col' is equivalent (w.r.t. the relation) to 'row'
+					assert(UNDEF_PROJ == quotProj[col]);
+
+					quotProj[col] = row;
+				}
+			}
+		}
+	}
+
+
+	friend std::ostream& operator<<(
+		std::ostream&             os,
+		const BinaryRelation&     v)
+	{
+		for (size_t i = 0; i < v.size_; ++i)
+		{
+			for (size_t j = 0; j < v.size_; ++j)
+			{
+				os << v.get(i, j);
+			}
+
+			os << std::endl;
+		}
+
+		return os;
+	}
+};
+
+class Vata2::Util::Identity
+{
+private:  // data members
+
+	size_t size_;
+
+public:   // methods
+
+	bool get(size_t r, size_t c) const
+	{
+		assert(r < size_);
+		assert(c < size_);
+
+		return r == c;
+	}
+
+	size_t size() const
+	{
+		return size_;
+	}
+
+public:
+
+	using IndexType    = std::unordered_map<size_t, std::vector<size_t>>;
+
+	explicit Identity(size_t size) :
+		size_(size)
+	{ }
+
+	bool sym(size_t r, size_t c) const
+	{
+		assert(r < size_);
+		assert(c < size_);
+
+		return r == c;
+	}
+
+	// build equivalence classes
+	void buildClasses(std::vector<size_t>& headIndex) const
+	{
+		headIndex.resize(size_);
+		std::vector<size_t> head;
+
+		for (size_t i = 0; i < size_; ++i)
+		{
+			size_t j = 0;
+			while ((j < head.size()) && !this->sym(i, head[j]))
+			{
+				++j;
+			}
+
+			if (j < head.size())
+			{
+				headIndex[i] = head[j];
+			}
+			else
+			{
+				headIndex[i] = i;
+				head.push_back(i);
+			}
+		}
+	}
+
+	// build equivalence classes
+	void buildClasses(
+		std::vector<size_t>& index,
+		std::vector<size_t>& head) const
+	{
+		index.resize(size_);
+		head.clear();
+		for (size_t i = 0; i < size_; ++i)
+		{
+			size_t j = 0;
+			while ((j < head.size()) && !this->sym(i, head[j]))
+			{
+				++j;
+			}
+
+			if (j < head.size())
+			{
+				index[i] = j;
+			}
+			else
+			{
+				index[i] = head.size();
+				head.push_back(i);
+			}
+		}
+	}
+
+	// relation index
+	void buildIndex(IndexType& dst) const
+	{
+		assert(dst.empty());
+
+		for (size_t i = 0; i < size_; ++i)
+		{
+			bool inserted = dst.insert(std::make_pair(i, std::vector<size_t>({i}))).second;
+			if (!inserted)  assert(false);
+		}
+	}
+
+	// inverted relation index
+	void buildInvIndex(IndexType& dst) const
+	{
+		assert(dst.empty());
+		this->buildIndex(dst);
+	}
+
+	// relation index
+	void buildIndex(IndexType& ind, IndexType& inv) const
+	{
+		assert(ind.empty());
+		assert(inv.empty());
+
+		this->buildIndex(ind);
+		inv = ind;
+	}
+
+	friend std::ostream& operator<<(
+		std::ostream&        os,
+		const Identity&      v)
+	{
+		for (size_t i = 0; i < v.size(); ++i)
+		{
+			for (size_t j = 0; j < v.size(); ++j)
+			{
+				os << v.get(i, j);
+			}
+			os << std::endl;
+		}
+
+		return os;
+	}
+};
+
+/**
+ * @brief  A binary relation with discontinuous indexing
+ */
+class Vata2::Util::DiscontBinaryRelation
+{
+public:   // data types
+
+	using IndexType    = std::unordered_map<size_t, std::vector<size_t>>;
+	// using DictType     = std::unordered_map<size_t, size_t>;
+	using DictType     = Vata2::Util::TwoWayDict<size_t, size_t,
+		std::unordered_map<size_t, size_t>, std::unordered_map<size_t, size_t>>;
+	using TranslType   = Vata2::Util::TranslatorWeak<DictType>;
+
+private:  // data members
+
+	/// The underlying binary relation, indexed from 0
+	BinaryRelation rel_;
+
+	/// The counter of allocated indices
+	size_t indexCnt_;
+
+	/// The mapping of inputs to the range 0..size-1
+	DictType dict_;
+
+	/// The translator for indices
+	TranslType transl_;
+
+private:  // methods
+
+	/**
+	 * @brief  Translates index of internal relation to the discontinuous
+	 *
+	 * @param[in,out]  innerIndex  The index for the internal continuous relation
+	 *
+	 * @returns  The index in the discontinuous relation
+	 *
+	 * @note  Destroys @p innerIndex
+	 *
+	 * @note  Is this optimal?
+	 */
+	IndexType translateIndexToDiscont(
+		BinaryRelation::IndexType&      innerIndex) const
+	{
+		IndexType result;
+
+		for (size_t x = 0; x < innerIndex.size(); ++x)
+		{
+			std::vector<size_t>& images = innerIndex[x];
+
+			// 'std::transform' is C++ for 'map' in Haskell
+			std::transform(
+				/* where to start */ images.cbegin(),
+				/* where to finish */ images.cend(),
+				/* where to insert the results */ images.begin(),
+				/* what to compute */ [this](size_t img) { return dict_.TranslateBwd(img);});
+
+			bool inserted = result.insert(
+				std::make_pair(dict_.TranslateBwd(x), std::move(images))).second;
+			if (!inserted)  assert(false);
+		}
+
+		return result;
+	}
+
+public:   // methods
+
+	/**
+	 * @brief  The constructor
+	 */
+	DiscontBinaryRelation(
+		size_t         size = 0,
+		bool           defVal = false,
+		size_t         rowSize = 16) :
+		rel_(size, defVal, rowSize),
+		indexCnt_(0),
+		dict_(),
+		transl_(dict_, [this](const size_t&){return indexCnt_++;})
+	{ }
+
+
+	/**
+	 * @brief  Constructor from a binary relation and a dictionary with copy semantics
+	 *
+	 * @note This allows a conversion from TDict to DictType
+	 */
+	template <
+		class TDict>
+	DiscontBinaryRelation(
+		const BinaryRelation&      rel,
+		const TDict&               dict) :
+		rel_(rel),
+		indexCnt_(0),
+		dict_(dict),
+		transl_(dict_, [this](const size_t&){return indexCnt_++;})
+	{ }
+
+
+	/**
+	 * @brief  Constructor from a binary relation and a dictionary with copy semantics
+	 */
+	DiscontBinaryRelation(
+		const BinaryRelation&      rel,
+		const DictType&            dict) :
+		rel_(rel),
+		indexCnt_(0),
+		dict_(dict),
+		transl_(dict_, [this](const size_t&){return indexCnt_++;})
+	{ }
+
+
+	/**
+	 * @brief  Constructor from a binary relation and a dictionary with move semantics
+	 *
+	 * @note This allows a conversion from TDict to DictType
+	 */
+	template <
+		class TDict>
+	DiscontBinaryRelation(
+		BinaryRelation&&      rel,
+		TDict&&               dict) :
+		rel_(rel),
+		indexCnt_(0),
+		dict_(dict),
+		transl_(dict_, [this](const size_t&){return indexCnt_++;})
+	{ }
+
+	/**
+	 * @brief  Constructor from a binary relation and a dictionary with move semantics
+	 */
+	DiscontBinaryRelation(
+		BinaryRelation&&      rel,
+		DictType&&            dict) :
+		rel_(rel),
+		indexCnt_(0),
+		dict_(dict),
+		transl_(dict_, [this](const size_t&){return indexCnt_++;})
+	{ }
+
+
+	/**
+	 * @brief  Copy constructor
+	 */
+	DiscontBinaryRelation(const DiscontBinaryRelation& rhs) :
+		rel_(rhs.rel_),
+		indexCnt_(rhs.indexCnt_),
+		dict_(rhs.dict_),
+		transl_(dict_, [this](const size_t&){return indexCnt_++;})
+	{ }
+
+
+	/**
+	 * @brief  Move constructor
+	 */
+	DiscontBinaryRelation(DiscontBinaryRelation&& rhs) :
+		rel_(rhs.rel_),
+		indexCnt_(rhs.indexCnt_),
+		dict_(rhs.dict_),
+		transl_(dict_, [this](const size_t&){return indexCnt_++;})
+	{ }
+
+
+	/**
+	 * @brief  Assignment operator
+	 */
+	DiscontBinaryRelation& operator=(const DiscontBinaryRelation& rhs)
+	{
+		if (this != &rhs)
+		{
+			rel_ = rhs.rel_;
+			dict_ = rhs.dict_;
+			indexCnt_ = rhs.indexCnt_;
+
+			// the following (or a similar thing because this does not work) should
+			// not be necessary because dict_ is used as a reference
+			//
+			// transl_ = TranslType(dict_, [this](const size_t&){return indexCnt_++;});
+		}
+
+		return *this;
+	}
+
+
+	/**
+	 * @brief  Move assignment operator
+	 */
+	DiscontBinaryRelation& operator=(DiscontBinaryRelation&& rhs)
+	{
+		assert(this != &rhs);
+
+		rel_ = std::move(rhs.rel_);
+		dict_ = std::move(rhs.dict_);
+		indexCnt_ = std::move(rhs.indexCnt_);
+
+		// the following (or a similar thing because this does not work) should
+		// not be necessary because dict_ is used as a reference
+		//
+		// transl_ = TranslType(dict_, [this](const size_t&){return indexCnt_++;});
+
+		return *this;
+	}
+
+	std::string ToString() const
+	{
+		std::ostringstream str;
+
+		str << "{";
+		bool placeComma = false;
+		for (auto firstStateToMappedPair : dict_)
+		{	// iterate over all pairs
+			for (auto secondStateToMappedPair : dict_)
+			{
+				if (this->get(firstStateToMappedPair.first, secondStateToMappedPair.first))
+				{	// if the pair is in the relation print
+					str << (placeComma? ", " : "");
+					str << "(" << firstStateToMappedPair.first << ", " <<
+						secondStateToMappedPair.first << ")";
+					placeComma = true;
+				}
+			}
+		}
+		str << "}";
+
+		return str.str();
+	}
+
+	/**
+	 * @brief  Output stream operator
+	 */
+	friend std::ostream& operator<<(
+		std::ostream&                     os,
+		const DiscontBinaryRelation&      rel)
+	{
+		os << rel.ToString();
+
+		return os;
+	}
+
+
+	/**
+	 * @brief  Creates a mapping from elements to their images
+	 *
+	 * This method maps elements to their images. Formally, it creates for each
+	 * element 'x' the mapping 'x -> Y' where 'Y = {y | xRy}'
+	 *
+	 * @param[out]  dst  The result mapping every element to its images
+	 */
+	void buildIndex(IndexType& dst) const
+	{
+		assert(dst.empty());
+
+		std::vector<std::vector<size_t>> innerIndex;
+
+		rel_.buildIndex(innerIndex);
+		dst = this->translateIndexToDiscont(innerIndex);
+	}
+
+	// relation index
+	void buildIndex(
+		IndexType&           ind,
+		IndexType&           inv) const
+	{
+		assert(ind.empty());
+		assert(inv.empty());
+
+		std::vector<std::vector<size_t>> innerInd;
+		std::vector<std::vector<size_t>> innerInv;
+
+		rel_.buildIndex(innerInd, innerInv);
+		assert(innerInd.size() == innerInv.size());
+		ind = translateIndexToDiscont(innerInd);
+		inv = translateIndexToDiscont(innerInv);
+	}
+
+	bool get(size_t row, size_t column) const
+	{
+		size_t rowTransl = transl_.at(row);
+		size_t colTransl = transl_.at(column);
+		return rel_.get(rowTransl, colTransl);
+	}
+
+	void set(size_t row, size_t column, bool value)
+	{
+		rel_.set(transl_[row], transl_[column], value);
+	}
+
+	size_t size() const
+	{
+		return rel_.size();
+	}
+
+	/**
+	 * @brief  Restricts the relation to its symmetric fragment
+	 */
+	void RestrictToSymmetric()
+	{
+		rel_.RestrictToSymmetric();
+	}
+
+
+	/**
+	 * @brief  Gets the projection of elements to their representatives
+	 *
+	 * This method relies on the fact that @p *this represents an equivalance
+	 * relation (the result is undefined otherwise). The method creates the
+	 * projection of elements to their representatives in the quotient set
+	 * induced by the equivalence relation represented by @p *this.
+	 *
+	 * @param[out]  quotProj  The projection of elements to their representatives
+	 *                        in the quotient set
+	 */
+	template <
+		class MapType>
+	void GetQuotientProjection(
+		MapType&       quotProj)
+	{
+		assert(quotProj.empty());
+
+		std::vector<size_t> innerProj;
+
+		// get the vector for continuous values
+		rel_.GetQuotientProjection(innerProj);
+
+		for (size_t i = 0; i < innerProj.size(); ++i)
+		{	// go over all elements in the vector
+			bool inserted = quotProj.insert(
+				std::make_pair(dict_.TranslateBwd(i), dict_.TranslateBwd(innerProj[i]))).second;
+			if (!inserted)  assert(false);
+		}
+	}
+};
+
+#endif

--- a/include/vata2/simutil/binary_relation.hh
+++ b/include/vata2/simutil/binary_relation.hh
@@ -372,7 +372,7 @@ public:
 	/**
 	 * @brief  Restricts the relation to its symmetric fragment
 	 */
-	void RestrictToSymmetric()
+	void restrict_to_symmetric()
 	{
 		for (size_t row = 0; row < this->size(); ++row)
 		{
@@ -878,9 +878,9 @@ public:   // methods
 	/**
 	 * @brief  Restricts the relation to its symmetric fragment
 	 */
-	void RestrictToSymmetric()
+	void restrict_to_symmetric()
 	{
-		rel_.RestrictToSymmetric();
+		rel_.restrict_to_symmetric();
 	}
 
 

--- a/include/vata2/simutil/binary_relation.hh
+++ b/include/vata2/simutil/binary_relation.hh
@@ -196,7 +196,7 @@ public:
 	}
 
 	// build equivalence classes
-	void build_classes(std::vector<size_t>& headIndex) const
+	void build_equivalence_classes(std::vector<size_t>& headIndex) const
 	{
 		headIndex.resize(size_);
 		std::vector<size_t> head;
@@ -221,7 +221,7 @@ public:
 	}
 
 	// build equivalence classes
-	void build_classes(
+	void build_equivalence_classes(
 		std::vector<size_t>&       index,
 		std::vector<size_t>&       head) const
 	{
@@ -487,7 +487,7 @@ public:
 	}
 
 	// build equivalence classes
-	void build_classes(std::vector<size_t>& headIndex) const
+	void build_equivalence_classes(std::vector<size_t>& headIndex) const
 	{
 		headIndex.resize(size_);
 		std::vector<size_t> head;
@@ -513,7 +513,7 @@ public:
 	}
 
 	// build equivalence classes
-	void build_classes(
+	void build_equivalence_classes(
 		std::vector<size_t>& index,
 		std::vector<size_t>& head) const
 	{

--- a/include/vata2/simutil/binary_relation.hh
+++ b/include/vata2/simutil/binary_relation.hh
@@ -77,8 +77,8 @@ protected:
 /*
 	void shrinkToFit() {
 
-		assert(this->rowSize_ > this->size_);
-		size_t newRowSize = this->rowSize_;
+		assert(this->row_size_ > this->size_);
+		size_t newRowSize = this->row_size_;
 		while (this->size_ < (newRowSize >> 1))
 			newRowSize >>= 1;
 		assert(this->size_ <= newRowSize);
@@ -185,7 +185,7 @@ public:
 
 /*
 	BinaryRelation(const BinaryRelation& rel)
-		: data_(rel.data_), rowSize_(rel.rowSize_), size_(rel.size_) {}
+		: data_(rel.data_), row_size_(rel.row_size_), size_(rel.size_) {}
 */
 
 	BinaryRelation(const std::vector<std::vector<bool> >& rel) :

--- a/include/vata2/simutil/binary_relation.hh
+++ b/include/vata2/simutil/binary_relation.hh
@@ -212,7 +212,7 @@ public:
 	}
 
 	// build equivalence classes
-	void buildClasses(std::vector<size_t>& headIndex) const
+	void build_classes(std::vector<size_t>& headIndex) const
 	{
 		headIndex.resize(size_);
 		std::vector<size_t> head;
@@ -237,7 +237,7 @@ public:
 	}
 
 	// build equivalence classes
-	void buildClasses(
+	void build_classes(
 		std::vector<size_t>&       index,
 		std::vector<size_t>&       head) const
 	{
@@ -304,9 +304,9 @@ public:
 	 *
 	 * @param[out]  dst  The result mapping every element to its images
 	 *
-	 * @see  buildInvIndex
+	 * @see  build_inv_index
 	 */
-	void buildIndex(IndexType& dst) const
+	void build_index(IndexType& dst) const
 	{
 		dst.resize(size_);
 
@@ -338,9 +338,9 @@ public:
 	 *
 	 * @param[out]  dst  The result mapping every element to its co-images
 	 *
-	 * @see buildIndex
+	 * @see build_index
 	 */
-	void buildInvIndex(IndexType& dst) const
+	void build_inv_index(IndexType& dst) const
 	{
 		dst.resize(size_);
 
@@ -359,15 +359,15 @@ public:
 	/**
 	 * @brief  Creates a mapping from elements to their images and co-images
 	 *
-	 * This method the call to buildIndex and buildInvIndex, i.e. it maps
+	 * This method the call to build_index and build_inv_index, i.e. it maps
 	 * elements to their images (in @p ind) and their co-images (in @p inv).
 	 *
 	 * @param[out]  ind  The result mapping every element to its images
 	 * @param[out]  inv  The result mapping every element to its co-images
 	 *
-	 * @see buildIndex buildInvIndex
+	 * @see build_index build_inv_index
 	 */
-	void buildIndex(IndexType& ind, IndexType& inv) const
+	void build_index(IndexType& ind, IndexType& inv) const
 	{
 		ind.resize(size_);
 		inv.resize(size_);
@@ -414,7 +414,7 @@ public:
 	 *                        representatives in the quotient set, quotProj[i] is
 	 *                        the number that the i-th guy maps to
 	 */
-	void GetQuotientProjection(
+	void get_quotient_projection(
 		std::vector<size_t>&             quotProj)
 	{
 		const size_t UNDEF_PROJ = static_cast<size_t>(-1);
@@ -488,7 +488,7 @@ public:   // methods
 
 public:
 
-	using IndexType    = std::unordered_map<size_t, std::vector<size_t>>;
+	using IndexType = std::unordered_map<size_t, std::vector<size_t>>;
 
 	explicit Identity(size_t size) :
 		size_(size)
@@ -503,7 +503,7 @@ public:
 	}
 
 	// build equivalence classes
-	void buildClasses(std::vector<size_t>& headIndex) const
+	void build_classes(std::vector<size_t>& headIndex) const
 	{
 		headIndex.resize(size_);
 		std::vector<size_t> head;
@@ -529,7 +529,7 @@ public:
 	}
 
 	// build equivalence classes
-	void buildClasses(
+	void build_classes(
 		std::vector<size_t>& index,
 		std::vector<size_t>& head) const
 	{
@@ -556,7 +556,7 @@ public:
 	}
 
 	// relation index
-	void buildIndex(IndexType& dst) const
+	void build_index(IndexType& dst) const
 	{
 		assert(dst.empty());
 
@@ -568,19 +568,19 @@ public:
 	}
 
 	// inverted relation index
-	void buildInvIndex(IndexType& dst) const
+	void build_inv_index(IndexType& dst) const
 	{
 		assert(dst.empty());
-		this->buildIndex(dst);
+		this->build_index(dst);
 	}
 
 	// relation index
-	void buildIndex(IndexType& ind, IndexType& inv) const
+	void build_index(IndexType& ind, IndexType& inv) const
 	{
 		assert(ind.empty());
 		assert(inv.empty());
 
-		this->buildIndex(ind);
+        this->build_index(ind);
 		inv = ind;
 	}
 
@@ -620,7 +620,7 @@ private:  // data members
 	BinaryRelation rel_;
 
 	/// The counter of allocated indices
-	size_t indexCnt_;
+	size_t index_cnt_;
 
 	/// The mapping of inputs to the range 0..size-1
 	DictType dict_;
@@ -633,32 +633,32 @@ private:  // methods
 	/**
 	 * @brief  Translates index of internal relation to the discontinuous
 	 *
-	 * @param[in,out]  innerIndex  The index for the internal continuous relation
+	 * @param[in,out]  inner_index  The index for the internal continuous relation
 	 *
 	 * @returns  The index in the discontinuous relation
 	 *
-	 * @note  Destroys @p innerIndex
+	 * @note  Destroys @p inner_index
 	 *
 	 * @note  Is this optimal?
 	 */
-	IndexType translateIndexToDiscont(
-		BinaryRelation::IndexType&      innerIndex) const
+	IndexType translate_index_to_discont(
+		BinaryRelation::IndexType&      inner_index) const
 	{
 		IndexType result;
 
-		for (size_t x = 0; x < innerIndex.size(); ++x)
+		for (size_t x = 0; x < inner_index.size(); ++x)
 		{
-			std::vector<size_t>& images = innerIndex[x];
+			std::vector<size_t>& images = inner_index[x];
 
 			// 'std::transform' is C++ for 'map' in Haskell
 			std::transform(
 				/* where to start */ images.cbegin(),
 				/* where to finish */ images.cend(),
 				/* where to insert the results */ images.begin(),
-				/* what to compute */ [this](size_t img) { return dict_.TranslateBwd(img);});
+				/* what to compute */ [this](size_t img) { return dict_.translate_bwd(img);});
 
 			bool inserted = result.insert(
-				std::make_pair(dict_.TranslateBwd(x), std::move(images))).second;
+				std::make_pair(dict_.translate_bwd(x), std::move(images))).second;
 			if (!inserted)  assert(false);
 		}
 
@@ -674,10 +674,10 @@ public:   // methods
 		size_t         size = 0,
 		bool           defVal = false,
 		size_t         rowSize = 16) :
-		rel_(size, defVal, rowSize),
-		indexCnt_(0),
-		dict_(),
-		transl_(dict_, [this](const size_t&){return indexCnt_++;})
+			rel_(size, defVal, rowSize),
+			index_cnt_(0),
+			dict_(),
+			transl_(dict_, [this](const size_t&){return index_cnt_++;})
 	{ }
 
 
@@ -691,10 +691,10 @@ public:   // methods
 	DiscontBinaryRelation(
 		const BinaryRelation&      rel,
 		const TDict&               dict) :
-		rel_(rel),
-		indexCnt_(0),
-		dict_(dict),
-		transl_(dict_, [this](const size_t&){return indexCnt_++;})
+			rel_(rel),
+			index_cnt_(0),
+			dict_(dict),
+			transl_(dict_, [this](const size_t&){return index_cnt_++;})
 	{ }
 
 
@@ -704,10 +704,10 @@ public:   // methods
 	DiscontBinaryRelation(
 		const BinaryRelation&      rel,
 		const DictType&            dict) :
-		rel_(rel),
-		indexCnt_(0),
-		dict_(dict),
-		transl_(dict_, [this](const size_t&){return indexCnt_++;})
+			rel_(rel),
+			index_cnt_(0),
+			dict_(dict),
+			transl_(dict_, [this](const size_t&){return index_cnt_++;})
 	{ }
 
 
@@ -722,9 +722,9 @@ public:   // methods
 		BinaryRelation&&      rel,
 		TDict&&               dict) :
 		rel_(rel),
-		indexCnt_(0),
+		index_cnt_(0),
 		dict_(dict),
-		transl_(dict_, [this](const size_t&){return indexCnt_++;})
+		transl_(dict_, [this](const size_t&){return index_cnt_++;})
 	{ }
 
 	/**
@@ -733,10 +733,10 @@ public:   // methods
 	DiscontBinaryRelation(
 		BinaryRelation&&      rel,
 		DictType&&            dict) :
-		rel_(rel),
-		indexCnt_(0),
-		dict_(dict),
-		transl_(dict_, [this](const size_t&){return indexCnt_++;})
+			rel_(rel),
+			index_cnt_(0),
+			dict_(dict),
+			transl_(dict_, [this](const size_t&){return index_cnt_++;})
 	{ }
 
 
@@ -745,9 +745,9 @@ public:   // methods
 	 */
 	DiscontBinaryRelation(const DiscontBinaryRelation& rhs) :
 		rel_(rhs.rel_),
-		indexCnt_(rhs.indexCnt_),
+		index_cnt_(rhs.index_cnt_),
 		dict_(rhs.dict_),
-		transl_(dict_, [this](const size_t&){return indexCnt_++;})
+		transl_(dict_, [this](const size_t&){return index_cnt_++;})
 	{ }
 
 
@@ -756,9 +756,9 @@ public:   // methods
 	 */
 	DiscontBinaryRelation(DiscontBinaryRelation&& rhs) :
 		rel_(rhs.rel_),
-		indexCnt_(rhs.indexCnt_),
+		index_cnt_(rhs.index_cnt_),
 		dict_(rhs.dict_),
-		transl_(dict_, [this](const size_t&){return indexCnt_++;})
+		transl_(dict_, [this](const size_t&){return index_cnt_++;})
 	{ }
 
 
@@ -771,12 +771,12 @@ public:   // methods
 		{
 			rel_ = rhs.rel_;
 			dict_ = rhs.dict_;
-			indexCnt_ = rhs.indexCnt_;
+			index_cnt_ = rhs.index_cnt_;
 
 			// the following (or a similar thing because this does not work) should
 			// not be necessary because dict_ is used as a reference
 			//
-			// transl_ = TranslType(dict_, [this](const size_t&){return indexCnt_++;});
+			// transl_ = TranslType(dict_, [this](const size_t&){return index_cnt_++;});
 		}
 
 		return *this;
@@ -792,17 +792,17 @@ public:   // methods
 
 		rel_ = std::move(rhs.rel_);
 		dict_ = std::move(rhs.dict_);
-		indexCnt_ = std::move(rhs.indexCnt_);
+		index_cnt_ = std::move(rhs.index_cnt_);
 
 		// the following (or a similar thing because this does not work) should
 		// not be necessary because dict_ is used as a reference
 		//
-		// transl_ = TranslType(dict_, [this](const size_t&){return indexCnt_++;});
+		// transl_ = TranslType(dict_, [this](const size_t&){return index_cnt_++;});
 
 		return *this;
 	}
 
-	std::string ToString() const
+	std::string to_string() const
 	{
 		std::ostringstream str;
 
@@ -833,7 +833,7 @@ public:   // methods
 		std::ostream&                     os,
 		const DiscontBinaryRelation&      rel)
 	{
-		os << rel.ToString();
+		os << rel.to_string();
 
 		return os;
 	}
@@ -847,18 +847,18 @@ public:   // methods
 	 *
 	 * @param[out]  dst  The result mapping every element to its images
 	 */
-	void buildIndex(IndexType& dst) const
+	void build_index(IndexType& dst) const
 	{
 		assert(dst.empty());
 
 		std::vector<std::vector<size_t>> innerIndex;
 
-		rel_.buildIndex(innerIndex);
-		dst = this->translateIndexToDiscont(innerIndex);
+		rel_.build_index(innerIndex);
+		dst = this->translate_index_to_discont(innerIndex);
 	}
 
 	// relation index
-	void buildIndex(
+	void build_index(
 		IndexType&           ind,
 		IndexType&           inv) const
 	{
@@ -868,10 +868,10 @@ public:   // methods
 		std::vector<std::vector<size_t>> innerInd;
 		std::vector<std::vector<size_t>> innerInv;
 
-		rel_.buildIndex(innerInd, innerInv);
+		rel_.build_index(innerInd, innerInv);
 		assert(innerInd.size() == innerInv.size());
-		ind = translateIndexToDiscont(innerInd);
-		inv = translateIndexToDiscont(innerInv);
+		ind = translate_index_to_discont(innerInd);
+		inv = translate_index_to_discont(innerInv);
 	}
 
 	bool get(size_t row, size_t column) const
@@ -908,25 +908,25 @@ public:   // methods
 	 * projection of elements to their representatives in the quotient set
 	 * induced by the equivalence relation represented by @p *this.
 	 *
-	 * @param[out]  quotProj  The projection of elements to their representatives
+	 * @param[out]  quot_proj  The projection of elements to their representatives
 	 *                        in the quotient set
 	 */
 	template <
 		class MapType>
-	void GetQuotientProjection(
-		MapType&       quotProj)
+	void get_quotient_projection(
+		MapType&       quot_proj)
 	{
-		assert(quotProj.empty());
+		assert(quot_proj.empty());
 
 		std::vector<size_t> innerProj;
 
 		// get the vector for continuous values
-		rel_.GetQuotientProjection(innerProj);
+		rel_.get_quotient_projection(innerProj);
 
 		for (size_t i = 0; i < innerProj.size(); ++i)
 		{	// go over all elements in the vector
-			bool inserted = quotProj.insert(
-				std::make_pair(dict_.TranslateBwd(i), dict_.TranslateBwd(innerProj[i]))).second;
+			bool inserted = quot_proj.insert(
+				std::make_pair(dict_.translate_bwd(i), dict_.translate_bwd(innerProj[i]))).second;
 			if (!inserted)  assert(false);
 		}
 	}

--- a/include/vata2/simutil/caching_allocator.hh
+++ b/include/vata2/simutil/caching_allocator.hh
@@ -1,0 +1,148 @@
+/*****************************************************************************
+ *  VATA Tree Automata Library
+ *
+ *  Copyright (c) 2011  Jiri Simacek <isimacek@fit.vutbr.cz>
+ *
+ *  Description:
+ *    Caching allocator template header file.
+ *
+ *****************************************************************************/
+
+#ifndef _VATA2_CACHING_ALLOCATOR_HH_
+#define _VATA2_CACHING_ALLOCATOR_HH_
+
+#include <cstdlib>
+
+#include <vector>
+#include <functional>
+
+#include <unordered_set>
+
+// insert class to proper namespace
+namespace Vata2 {
+	namespace Util {
+		template <class T, class Initializer = std::function<void(T*)>> class CachingAllocator;
+		template <class T, class Initializer = std::function<void(T*)>> class CachingArrayAllocator;
+	}
+}
+
+template <class T, class Initializer>
+class Vata2::Util::CachingAllocator {
+
+public:
+
+	typedef T* Ptr;
+
+private:
+
+	std::vector<T*> store_;
+	Initializer initializer_;
+
+public:
+
+	CachingAllocator() : store_(), initializer_([](T*){}) {}
+
+	CachingAllocator(Initializer initializer) : store_(), initializer_(initializer) {}
+
+	~CachingAllocator() {
+
+		for (auto& element : this->store_)
+			delete element;
+
+	}
+
+	Ptr operator()() {
+
+		Ptr ptr;
+
+		if (!this->store_.empty()) {
+
+			ptr = this->store_.back();
+			this->store_.pop_back();
+
+		} else {
+
+			ptr = new T();
+
+		}
+
+		this->initializer_(ptr);
+
+		return ptr;
+
+	}
+
+	void reclaim(Ptr ptr) {
+
+		this->store_.push_back(ptr);
+
+	}
+
+};
+
+template <class T, class Initializer>
+class Vata2::Util::CachingArrayAllocator {
+
+public:
+
+	typedef T* Ptr;
+
+private:
+
+	std::vector<T*> store_;
+	size_t size_;
+	size_t byteSize_;
+	Initializer initializer_;
+
+public:
+
+	CachingArrayAllocator(size_t size) : store_(), size_(size), byteSize_(size*sizeof(T)),
+		initializer_([](T*){}) {}
+
+	CachingArrayAllocator(size_t size, Initializer initializer) : store_(), size_(size),
+		byteSize_(size*sizeof(T)), initializer_(initializer) {}
+
+	~CachingArrayAllocator() {
+
+		for (auto& element : this->store_)
+			::operator delete(element);
+
+	}
+
+	Ptr operator()() {
+
+		Ptr ptr;
+
+		if (!this->store_.empty()) {
+
+			ptr = this->store_.back();
+
+			this->store_.pop_back();
+
+		} else {
+
+			ptr = reinterpret_cast<T*>(::operator new(this->byteSize_));
+
+		}
+
+		this->initializer_(ptr);
+
+		return ptr;
+
+	}
+
+	void reclaim(Ptr ptr) {
+
+		this->store_.push_back(ptr);
+
+	}
+
+	const size_t& size() const {
+
+		return this->size_;
+
+	}
+
+};
+
+#endif

--- a/include/vata2/simutil/caching_allocator.hh
+++ b/include/vata2/simutil/caching_allocator.hh
@@ -42,7 +42,7 @@ public:
 
 	CachingAllocator() : store_(), initializer_([](T*){}) {}
 
-	CachingAllocator(Initializer initializer) : store_(), initializer_(initializer) {}
+	explicit CachingAllocator(Initializer initializer) : store_(), initializer_(initializer) {}
 
 	~CachingAllocator() {
 
@@ -96,10 +96,10 @@ private:
 
 public:
 
-	CachingArrayAllocator(size_t size) : store_(), size_(size), byteSize_(size*sizeof(T)),
+    __attribute__((unused)) explicit CachingArrayAllocator(size_t size) : store_(), size_(size), byteSize_(size*sizeof(T)),
 		initializer_([](T*){}) {}
 
-	CachingArrayAllocator(size_t size, Initializer initializer) : store_(), size_(size),
+    __attribute__((unused)) CachingArrayAllocator(size_t size, Initializer initializer) : store_(), size_(size),
 		byteSize_(size*sizeof(T)), initializer_(initializer) {}
 
 	~CachingArrayAllocator() {

--- a/include/vata2/simutil/shared_counter.hh
+++ b/include/vata2/simutil/shared_counter.hh
@@ -216,7 +216,7 @@ public:
 	}
 
 	template <class T>
-	void copyLabels(const T& labels, SharedCounter& cnt) {
+	void copy_labels(const T& labels, SharedCounter& cnt) {
 
 		size_t sent = 0;
 

--- a/include/vata2/simutil/shared_counter.hh
+++ b/include/vata2/simutil/shared_counter.hh
@@ -47,10 +47,6 @@ private:
 
 	std::vector<Row> data_;
 
-protected:
-
-	SharedCounter& operator=(const SharedCounter& rhs);
-
 public:
 
 	SharedCounter(const Key& key, const size_t& states, const LabelMap& labelMap,

--- a/include/vata2/simutil/shared_counter.hh
+++ b/include/vata2/simutil/shared_counter.hh
@@ -142,7 +142,7 @@ public:
 		row.master_ = count;
 		row.data_ = this->allocator_();
 
-//		std::memset(row.data_, 0, this->rowSize_*sizeof(size_t));
+//		std::memset(row.data_, 0, this->row_size_*sizeof(size_t));
 
 //		assert(row.data_[colIndex] == 0);
 

--- a/include/vata2/simutil/shared_counter.hh
+++ b/include/vata2/simutil/shared_counter.hh
@@ -1,0 +1,294 @@
+/*****************************************************************************
+ *  VATA Tree Automata Library
+ *
+ *  Copyright (c) 2011  Jiri Simacek <isimacek@fit.vutbr.cz>
+ *
+ *  Description:
+ *    Source for shared counter class.
+ *
+ *****************************************************************************/
+
+#ifndef _VATA2_SHARED_COUNTER_HH_
+#define _VATA2_SHARED_COUNTER_HH_
+
+#include <cstring>
+#include <vector>
+
+#include <vata2/simutil/caching_allocator.hh>
+
+namespace Vata2 { namespace Util {
+	class SharedCounter;
+}}
+
+class Vata2::Util::SharedCounter
+{
+public:
+
+	typedef CachingArrayAllocator<size_t> Allocator;
+	typedef std::vector<size_t> Key;
+	typedef std::vector<std::pair<size_t, size_t>> LabelMap;
+
+private:
+
+	struct Row {
+
+		size_t master_;
+		size_t* data_;
+
+		Row() : master_(0), data_(nullptr) {}
+
+	};
+
+	const Key& key_;
+	const size_t& states_;
+	const LabelMap& labelMap_;
+	const size_t& rowSize_;
+	Allocator& allocator_;
+
+	std::vector<Row> data_;
+
+protected:
+
+	SharedCounter& operator=(const SharedCounter& rhs);
+
+public:
+
+	SharedCounter(const Key& key, const size_t& states, const LabelMap& labelMap,
+		const size_t& rowSize, Allocator& allocator) : key_(key), states_(states),
+		labelMap_(labelMap), rowSize_(rowSize), allocator_(allocator), data_() {}
+
+	SharedCounter(SharedCounter& counter) : key_(counter.key_), states_(counter.states_),
+		labelMap_(counter.labelMap_), rowSize_(counter.rowSize_), allocator_(counter.allocator_),
+		data_() {}
+
+	~SharedCounter() {
+
+		for (auto& row : this->data_) {
+
+			if (!row.data_)
+				continue;
+
+			if (!--(row.data_[this->rowSize_])) // refCount
+				this->allocator_.reclaim(row.data_);
+
+		}
+
+	}
+
+	void init() {
+
+		for (auto& row : this->data_) {
+
+			if (!row.data_)
+				continue;
+
+			if (row.data_[this->rowSize_] == 1)
+				continue;
+
+			// everything is in master
+			this->allocator_.reclaim(row.data_);
+
+			row.data_ = nullptr;
+
+		}
+
+	}
+
+	size_t get(size_t label, size_t state) const {
+
+		assert(label*this->states_ + state < this->key_.size());
+
+		size_t index = this->key_[label*this->states_ + state];
+		size_t rowIndex = index / this->rowSize_;
+		size_t colIndex = index % this->rowSize_;
+
+		assert(rowIndex < this->data_.size());
+
+		auto& row = this->data_[rowIndex];
+
+		if (!row.data_)
+			return row.master_;
+
+		return row.data_[colIndex];
+
+	}
+
+	void set(size_t label, size_t state, size_t count) {
+
+		assert(count);
+		assert(label*this->states_ + state < this->key_.size());
+
+		size_t index = this->key_[label*this->states_ + state];
+		size_t rowIndex = index / this->rowSize_;
+		size_t colIndex = index % this->rowSize_;
+
+		assert(rowIndex < this->data_.size());
+
+		auto& row = this->data_[rowIndex];
+
+		if (row.master_) {
+
+			assert(row.data_);
+			assert((row.data_[this->rowSize_] == 0) || (row.data_[this->rowSize_] == 1));
+
+			row.master_ += count;
+			row.data_[colIndex] = count;
+			row.data_[this->rowSize_] = 1; // refCount
+
+			return;
+
+		}
+
+		row.master_ = count;
+		row.data_ = this->allocator_();
+
+//		std::memset(row.data_, 0, this->rowSize_*sizeof(size_t));
+
+//		assert(row.data_[colIndex] == 0);
+
+		row.data_[this->rowSize_] = 0; // exploit refCount
+		row.data_[colIndex] = count;
+
+	}
+
+	size_t decr(size_t label, size_t state) {
+
+		assert(label*this->states_ + state < this->key_.size());
+
+		size_t index = this->key_[label*this->states_ + state];
+		size_t rowIndex = index / this->rowSize_;
+		size_t colIndex = index % this->rowSize_;
+
+		assert(rowIndex < this->data_.size());
+
+		auto& row = this->data_[rowIndex];
+
+		assert(row.master_);
+
+		if (!row.data_) // everything is in master
+			return --row.master_;
+
+		if ((row.master_ == row.data_[colIndex]) || (row.master_ == 2)) {
+
+			// move everything to master
+
+			--row.master_;
+
+			size_t result = (row.data_[colIndex] - 1);
+
+			if (!--(row.data_[this->rowSize_])) // refCount
+				this->allocator_.reclaim(row.data_);
+
+			row.data_ = nullptr;
+
+			return result;
+
+		}
+
+		if (row.data_[this->rowSize_] > 1) { // refCount
+
+			--(row.data_[this->rowSize_]); // refCount
+
+			auto newData = this->allocator_();
+
+			std::memcpy(newData, row.data_, this->rowSize_*sizeof(size_t));
+
+			assert(newData[colIndex] == row.data_[colIndex]);
+
+			newData[this->rowSize_] = 1; // refCount
+
+			row.data_ = newData;
+
+		}
+
+		assert(row.data_[this->rowSize_] == 1);
+
+		--row.master_;
+
+		return --(row.data_[colIndex]);
+
+	}
+
+	void resize(size_t rowCount) {
+
+		this->data_.resize(rowCount);
+
+	}
+
+	template <class T>
+	void copyLabels(const T& labels, SharedCounter& cnt) {
+
+		size_t sent = 0;
+
+		std::vector<std::pair<size_t, size_t>> ranges;
+
+		for (auto& label : labels) {
+
+			assert(label < this->labelMap_.size());
+
+			size_t end = std::min(cnt.data_.size(), this->labelMap_[label].second);
+
+			if (end <= this->labelMap_[label].first)
+				continue;
+
+			ranges.push_back(std::make_pair(this->labelMap_[label].first, end));
+
+			sent = std::max(sent, end);
+
+		}
+
+		this->data_.resize(sent);
+
+		std::vector<bool> rowMask(sent, false);
+
+		for (auto& range : ranges) {
+
+			for (size_t i = range.first; i < range.second; ++i) {
+
+				if (rowMask[i])
+					continue;
+
+				rowMask[i] = true;
+
+				auto& src = cnt.data_[i];
+				auto& dst = this->data_[i];
+
+				dst.master_ = src.master_;
+
+				if (!src.data_)
+					continue;
+
+				++(src.data_[this->rowSize_]); // refCount
+
+				dst.data_ = src.data_;
+
+			}
+
+		}
+
+	}
+
+	friend std::ostream& operator<<(std::ostream& os, const SharedCounter& cnt) {
+
+		for (auto& row : cnt.data_) {
+
+			os << row.master_ << ':';
+
+			if (row.data_) {
+
+				for (size_t col = 0; col < cnt.rowSize_; ++col)
+					os << ' ' << row.data_[col];
+
+				os << std::endl;
+
+			}
+
+		}
+
+		return os;
+
+	}
+
+};
+
+#endif

--- a/include/vata2/simutil/shared_list.hh
+++ b/include/vata2/simutil/shared_list.hh
@@ -38,22 +38,22 @@ private:
 		typename T::const_iterator iter_;
 
 		Iterator() : pos_(nullptr), iter_() {}
-		Iterator(const SharedList* pos) : pos_(pos), iter_(pos->subList_->begin()) {}
+		Iterator(const SharedList* pos) : pos_(pos), iter_(pos->sublist_->begin()) {}
 
 		Iterator& operator++()
 		{
 			// Assertions
 			assert(pos_);
-			assert(pos_->subList_);
+			assert(pos_->sublist_);
 
-			if (++iter_ != pos_->subList_->end())
+			if (++iter_ != pos_->sublist_->end())
 				return *this;
 
 			if ((pos_ = pos_->next_) != nullptr) {
 				// Assertions
-				assert(pos_->subList_);
+				assert(pos_->sublist_);
 
-				iter_ = pos_->subList_->begin();
+				iter_ = pos_->sublist_->begin();
 			} else {
 				iter_ = typename T::const_iterator();
 			}
@@ -77,13 +77,13 @@ public:
 private:
 
 	SharedList* next_;
-	T* subList_;
-	size_t refCount_;
+	T* sublist_;
+	size_t refcount_;
 
 public:
 
 	SharedList(T* subList = nullptr) :
-		next_(nullptr), subList_(subList), refCount_(1)
+		next_(nullptr), sublist_(subList), refcount_(1)
 	{ }
 
 	void init(T* subList)
@@ -91,17 +91,17 @@ public:
 		// Assertions
 		assert(subList);
 
-		subList_ = subList;
+        sublist_ = subList;
 	}
 
-	T* subList() {return subList_;}
+	T* sublist() {return sublist_;}
 
 	template <class Deleter>
 	void release(const Deleter& deleter)
 	{
 		SharedList* elem = this, * tmp;
 
-		while (elem && elem->refCount_ == 1) {
+		while (elem && elem->refcount_ == 1) {
 			tmp = elem;
 			elem = elem->next_;
 			deleter(tmp);
@@ -112,22 +112,22 @@ public:
 	}
 
 	template <class Deleter>
-	void unsafeRelease(const Deleter& deleter)
+	void unsafe_release(const Deleter& deleter)
 	{
 		SharedList* elem = this;
 
-		while (elem && elem->refCount_ == 1) {
+		while (elem && elem->refcount_ == 1) {
 			deleter(elem);
 			elem = elem->next_;
 		}
 
 		if (elem)
-			--elem->refCount_;
+			--elem->refcount_;
 	}
 
 	SharedList* copy()
 	{
-		++refCount_;
+		++refcount_;
 
 		return this;
 	}
@@ -139,18 +139,18 @@ public:
 		if (!list) {
 			list = allocator();
 			list->next_ = nullptr;
-			list->subList_->push_back(v);
+			list->sublist_->push_back(v);
 
 			return true;
 		}
 
-		if (list->refCount_ > 1) {
+		if (list->refcount_ > 1) {
 			SharedList* tmp = allocator();
 			tmp->next_ = list;
 			list = tmp;
 		}
 
-		list->subList_->push_back(v);
+		list->sublist_->push_back(v);
 
 		return false;
 	}

--- a/include/vata2/simutil/shared_list.hh
+++ b/include/vata2/simutil/shared_list.hh
@@ -38,7 +38,7 @@ private:
 		typename T::const_iterator iter_;
 
 		Iterator() : pos_(nullptr), iter_() {}
-		Iterator(const SharedList* pos) : pos_(pos), iter_(pos->sublist_->begin()) {}
+		explicit Iterator(const SharedList* pos) : pos_(pos), iter_(pos->sublist_->begin()) {}
 
 		Iterator& operator++()
 		{
@@ -82,7 +82,7 @@ private:
 
 public:
 
-	SharedList(T* subList = nullptr) :
+	explicit SharedList(T* subList = nullptr) :
 		next_(nullptr), sublist_(subList), refcount_(1)
 	{ }
 

--- a/include/vata2/simutil/shared_list.hh
+++ b/include/vata2/simutil/shared_list.hh
@@ -1,0 +1,159 @@
+/*****************************************************************************
+ *  VATA Tree Automata Library
+ *
+ *  Copyright (c) 2011  Jiri Simacek <isimacek@fit.vutbr.cz>
+ *
+ *  Description:
+ *    Shared list template header file.
+ *
+ *****************************************************************************/
+
+#ifndef _VATA2_SHARED_LIST_HH_
+#define _VATA2_SHARED_LIST_HH_
+
+// insert class to proper namespace
+namespace Vata2 {
+	namespace Util {
+		template <class T> class SharedList;
+	}
+}
+
+/**
+ * @brief  A shared list
+ *
+ * A shared list with a reference counter
+ */
+template <class T>
+class Vata2::Util::SharedList {
+
+private:
+
+	struct Iterator {
+		typedef std::input_iterator_tag iterator_category;
+		typedef size_t value_type;
+		typedef size_t* pointer;
+		typedef size_t& reference;
+
+		const SharedList* pos_;
+		typename T::const_iterator iter_;
+
+		Iterator() : pos_(nullptr), iter_() {}
+		Iterator(const SharedList* pos) : pos_(pos), iter_(pos->subList_->begin()) {}
+
+		Iterator& operator++()
+		{
+			// Assertions
+			assert(pos_);
+			assert(pos_->subList_);
+
+			if (++iter_ != pos_->subList_->end())
+				return *this;
+
+			if ((pos_ = pos_->next_) != nullptr) {
+				// Assertions
+				assert(pos_->subList_);
+
+				iter_ = pos_->subList_->begin();
+			} else {
+				iter_ = typename T::const_iterator();
+			}
+
+			return *this;
+		}
+
+		Iterator operator++(int) const {return ++Iterator(pos_);}
+		bool operator==(const Iterator& rhs) const {return iter_ == rhs.iter_;}
+		bool operator!=(const Iterator& rhs) const {return iter_ != rhs.iter_;}
+		const size_t& operator*() const {return *iter_;}
+	}; // struct Iterator
+
+public:
+
+	typedef Iterator const_iterator;
+
+	const_iterator begin() const {return const_iterator(this);}
+	const_iterator end() const {return const_iterator();}
+
+private:
+
+	SharedList* next_;
+	T* subList_;
+	size_t refCount_;
+
+public:
+
+	SharedList(T* subList = nullptr) :
+		next_(nullptr), subList_(subList), refCount_(1)
+	{ }
+
+	void init(T* subList)
+	{
+		// Assertions
+		assert(subList);
+
+		subList_ = subList;
+	}
+
+	T* subList() {return subList_;}
+
+	template <class Deleter>
+	void release(const Deleter& deleter)
+	{
+		SharedList* elem = this, * tmp;
+
+		while (elem && elem->refCount_ == 1) {
+			tmp = elem;
+			elem = elem->next_;
+			deleter(tmp);
+		}
+
+		if (elem)
+			--elem->counter_;
+	}
+
+	template <class Deleter>
+	void unsafeRelease(const Deleter& deleter)
+	{
+		SharedList* elem = this;
+
+		while (elem && elem->refCount_ == 1) {
+			deleter(elem);
+			elem = elem->next_;
+		}
+
+		if (elem)
+			--elem->refCount_;
+	}
+
+	SharedList* copy()
+	{
+		++refCount_;
+
+		return this;
+	}
+
+	template <class Allocator>
+	static bool append(SharedList*& list, const typename T::value_type& v,
+		Allocator& allocator)
+	{
+		if (!list) {
+			list = allocator();
+			list->next_ = nullptr;
+			list->subList_->push_back(v);
+
+			return true;
+		}
+
+		if (list->refCount_ > 1) {
+			SharedList* tmp = allocator();
+			tmp->next_ = list;
+			list = tmp;
+		}
+
+		list->subList_->push_back(v);
+
+		return false;
+	}
+};
+
+#endif

--- a/include/vata2/simutil/smart_set.hh
+++ b/include/vata2/simutil/smart_set.hh
@@ -205,7 +205,7 @@ public:
 		this->clear();
 	}
 
-	void assignFlat(const SmartSet& s)
+	void assign_flat(const SmartSet& s)
 	{
 		this->clear();
 		assert(nullptr == head_.next);
@@ -313,7 +313,7 @@ public:
 		}
 	}
 
-	void removeStrict(const Key& key)
+	void remove_strict(const Key& key)
 	{
 		assert(key < index_.size());
 		Element*& prev = index_[key];

--- a/include/vata2/simutil/smart_set.hh
+++ b/include/vata2/simutil/smart_set.hh
@@ -42,7 +42,7 @@ private:
 		Key key;
 		size_t count;
 
-		Element(
+		explicit Element(
 			const Key&         key,
 			size_t             count = 0) :
 			next(nullptr),
@@ -62,7 +62,7 @@ private:
 
 	public:
 
-		Iterator(const Element* element) :
+		explicit Iterator(const Element* element) :
 			element_(element)
 		{ }
 
@@ -156,7 +156,7 @@ protected:
 
 public:
 
-	SmartSet(
+	explicit SmartSet(
 		size_t         range = 0) :
 		head_(Key(), 0),
 		last_(&head_), size_(0),

--- a/include/vata2/simutil/smart_set.hh
+++ b/include/vata2/simutil/smart_set.hh
@@ -1,0 +1,376 @@
+/*****************************************************************************
+ *  VATA Tree Automata Library
+ *
+ *  Copyright (c) 2011  Jiri Simacek <isimacek@fit.vutbr.cz>
+ *
+ *  Description:
+ *    Header file for smart set.
+ *
+ *****************************************************************************/
+
+#ifndef _VATA2_SMART_SET_HH_
+#define _VATA2_SMART_SET_HH_
+
+// VATA headers
+#include <vata2/convert.hh>
+#include <vata2/simutil/vata.hh>
+
+// Standard library headers
+#include <algorithm>
+#include <ostream>
+#include <vector>
+
+namespace Vata2
+{
+	namespace Util
+	{
+		class SmartSet;
+	}
+}
+
+class Vata2::Util::SmartSet
+{
+public:
+
+	typedef size_t Key;
+
+private:
+
+	struct Element
+	{
+		Element* next;
+		Key key;
+		size_t count;
+
+		Element(
+			const Key&         key,
+			size_t             count = 0) :
+			next(nullptr),
+			key(key),
+			count(count)
+		{ }
+	};
+
+	GCC_DIAG_OFF(effc++)
+	class Iterator : public std::iterator<std::input_iterator_tag, Key>
+	{
+	GCC_DIAG_ON(effc++)
+
+	private:
+
+		const Element* element_;
+
+	public:
+
+		Iterator(const Element* element) :
+			element_(element)
+		{ }
+
+		Iterator& operator++()
+		{
+			assert(nullptr != element_);
+
+			element_ = element_->next;
+			return *this;
+		}
+
+		Iterator operator++(int) const
+		{
+			return ++Iterator(element_);
+		}
+
+		const Key& operator*()
+		{
+			assert(nullptr != element_);
+
+			return element_->key;
+		}
+
+		bool operator==(const Iterator& rhs) const
+		{
+			return element_ == rhs.element_;
+		}
+
+		bool operator!=(const Iterator& rhs) const
+		{
+			return element_ != rhs.element_;
+		}
+	};
+
+public:
+
+	typedef Iterator iterator;
+
+private:
+
+	Element head_;
+	Element* last_;
+	size_t size_;
+
+	std::vector<Element*> index_;
+
+protected:
+
+	size_t& insert(const Key& key)
+	{
+		assert(key < index_.size());
+
+		Element*& prev = index_[key];
+
+		if (nullptr == prev)
+		{
+			prev = last_;
+			prev->next = new Element(key);
+			last_ = prev->next;
+
+			++size_;
+		}
+
+		assert(key == prev->next->key);
+
+		return prev->next->count;
+	}
+
+	void erase(Element*& prev)
+	{
+		assert(nullptr != prev);
+
+		--size_;
+		Element* el = prev->next;
+
+		assert(nullptr != el);
+
+		prev->next = el->next;
+
+		if (nullptr != prev->next)
+		{
+			assert(prev->next->key < index_.size());
+			assert(index_[prev->next->key] == el);
+
+			index_[prev->next->key] = prev;
+		}
+
+		delete el;
+		prev = nullptr;
+	}
+
+public:
+
+	SmartSet(
+		size_t         range = 0) :
+		head_(Key(), 0),
+		last_(&head_), size_(0),
+		index_(range, nullptr)
+	{ }
+
+	SmartSet(const SmartSet& s) :
+		head_(Key(), 0),
+		last_(&head_),
+		size_(s.size_),
+		index_(s.index_.size(), nullptr)
+	{
+		for (const Element* el = s.head_.next; nullptr != el; el = el->next)
+		{
+			index_[el->key] = last_;
+			last_->next = new Element(el->key, el->count);
+			last_ = last_->next;
+		}
+	}
+
+	SmartSet& operator=(const SmartSet& s)
+	{
+		if (this != &s)
+		{
+			assert(nullptr == head_.next);
+
+			std::fill(index_.begin(), index_.end(), nullptr);
+			index_.resize(s.index_.size(), nullptr);
+			last_ = &head_;
+
+			for (const Element* el = s.head_.next; nullptr != el; el = el->next)
+			{
+				index_[el->key] = last_;
+				last_->next = new Element(el->key, el->count);
+				last_ = last_->next;
+			}
+
+			size_ = s.size();
+		}
+
+		return *this;
+	}
+
+	~SmartSet()
+	{
+		this->clear();
+	}
+
+	void assignFlat(const SmartSet& s)
+	{
+		this->clear();
+		assert(nullptr == head_.next);
+		assert(std::all_of(index_.cbegin(), index_.cend(), [](const Element* elem){return nullptr == elem;}));
+
+		index_.resize(s.index_.size(), nullptr);
+		last_ = &head_;
+
+		for (const Element* el = s.head_.next; nullptr != el; el = el->next)
+		{
+			index_[el->key] = last_;
+			last_->next = new Element(el->key, 1);
+			last_ = last_->next;
+		}
+
+		size_ = s.size();
+	}
+
+	SmartSet::iterator begin() const
+	{
+		return SmartSet::Iterator(head_.next);
+	}
+
+	SmartSet::iterator end() const
+	{
+		return SmartSet::Iterator(nullptr);
+	}
+
+	bool contains(const Key& key) const
+	{
+		assert(key < index_.size());
+
+		if (nullptr == index_[key])
+		{
+			return false;
+		}
+
+		assert(index_[key]->next);
+		assert(index_[key]->next->key == key);
+
+		return true;
+	}
+
+	size_t count(const Key& key) const
+	{
+		assert(key < index_.size());
+
+		if (nullptr == index_[key])
+		{
+			return 0;
+		}
+
+		assert(index_[key]->next);
+		assert(index_[key]->next->key == key);
+
+		return index_[key]->next->count;
+	}
+
+	void init(const Key& key, size_t count)
+	{
+		if (count > 0)
+		{
+			this->insert(key) = count;
+			return;
+		}
+
+		assert(key < index_.size());
+
+		Element*& prev = index_[key];
+
+		if (nullptr != prev)
+		{
+			this->erase(prev);
+		}
+	}
+
+	void add(const Key& key)
+	{
+		++this->insert(key);
+	}
+
+	void remove(const Key& key)
+	{
+		assert(key < index_.size());
+
+		Element*& prev = index_[key];
+
+		if (nullptr == prev)
+		{
+			return;
+		}
+
+		Element* el = prev->next;
+
+		assert(nullptr != el);
+		assert(key == el->key);
+
+		if (el->count == 1)
+		{
+			this->erase(prev);
+		}
+		else
+		{
+			--el->count;
+		}
+	}
+
+	void removeStrict(const Key& key)
+	{
+		assert(key < index_.size());
+		Element*& prev = index_[key];
+		assert(nullptr != prev);
+
+		Element* el = prev->next;
+		assert(key == el->key);
+
+		if (el->count == 1)
+		{
+			this->erase(prev);
+		}
+		else
+		{
+			--el->count;
+		}
+	}
+
+	bool empty() const
+	{
+		return head_.next == nullptr;
+	}
+
+	size_t size() const
+	{
+		return size_;
+	}
+
+	void clear()
+	{
+		for (Element* el = head_.next; nullptr != el; )
+		{
+			Element* tmp = el;
+			el = el->next;
+
+			assert(tmp->key < index_.size());
+
+			index_[tmp->key] = nullptr;
+			delete tmp;
+		}
+
+		last_ = &head_;
+		head_.next = nullptr;
+		size_ = 0;
+	}
+
+	friend std::ostream& operator<<(std::ostream& os, const SmartSet& s)
+	{
+		os << '{';
+
+		for (const Element* el = s.head_.next; nullptr != el; el = el->next)
+		{
+			os << ' ' << el->key << ':' << el->count;
+		}
+
+		return os << " }";
+	}
+};
+
+#endif

--- a/include/vata2/simutil/splitting_relation.hh
+++ b/include/vata2/simutil/splitting_relation.hh
@@ -1,0 +1,428 @@
+/*****************************************************************************
+ *  VATA Tree Automata Library
+ *
+ *  Copyright (c) 2011  Jiri Simacek <isimacek@fit.vutbr.cz>
+ *
+ *  Description:
+ *    Splitting relation class.
+ *
+ *****************************************************************************/
+
+#ifndef _VATA2_SPLITTING_RELATION_HH_
+#define _VATA2_SPLITTING_RELATION_HH_
+
+// Standard library headers
+#include <vector>
+
+// VATA headers
+#include <vata2/simutil/vata.hh>
+#include <vata2/simutil/caching_allocator.hh>
+
+namespace Vata2
+{
+	namespace Util
+	{
+		class SplittingRelation;
+	}
+}
+
+class Vata2::Util::SplittingRelation {
+
+	struct Element {
+
+		Element* up_;
+		Element* down_;
+		Element* left_;
+		Element* right_;
+		size_t col_;
+		size_t row_;
+
+		Element(size_t row = 0, size_t col = 0) : up_(), down_(), left_(), right_(), col_(col),
+			row_(row) {}
+
+	};
+
+	std::vector<std::pair<Element*, Element*>> columns_;
+	std::vector<std::pair<Element*, Element*>> rows_;
+	size_t size_;
+
+	CachingAllocator<Element> allocator_;
+
+	Element* colBegin(size_t col) {
+		return reinterpret_cast<Element*>(
+			reinterpret_cast<char*>(&this->columns_[col].first) - offsetof(Element, down_)
+		);
+	}
+
+	Element* colEnd(size_t col) {
+		return reinterpret_cast<Element*>(
+			reinterpret_cast<char*>(&this->columns_[col].second) - offsetof(Element, up_)
+		);
+	}
+
+	Element* rowBegin(size_t row) {
+		return reinterpret_cast<Element*>(
+			reinterpret_cast<char*>(&this->rows_[row].first) - offsetof(Element, right_)
+		);
+	}
+
+	Element* rowEnd(size_t row) {
+		return reinterpret_cast<Element*>(
+			reinterpret_cast<char*>(&this->rows_[row].second) - offsetof(Element, left_)
+		);
+	}
+
+	bool checkCol(size_t i) const {
+
+		assert(i < this->size_);
+
+		auto tmp = this->columns_[i].first;
+
+		while (tmp != this->columns_[i].second->down_) {
+
+			assert(tmp->up_->down_ == tmp);
+			assert(tmp->down_->up_ == tmp);
+			assert(tmp->left_->right_ == tmp);
+			assert(tmp->right_->left_ == tmp);
+
+			if (tmp->col_ != i)
+				return false;
+
+			if (tmp->row_ >= this->size_)
+				return false;
+
+			tmp = tmp->down_;
+
+		}
+
+		return true;
+
+	}
+
+	bool checkRow(size_t i) const {
+
+		assert(i < this->size_);
+
+		auto tmp = this->rows_[i].first;
+
+		while (tmp != this->rows_[i].second->right_) {
+
+			assert(tmp->up_->down_ == tmp);
+			assert(tmp->down_->up_ == tmp);
+			assert(tmp->left_->right_ == tmp);
+			assert(tmp->right_->left_ == tmp);
+
+			if (tmp->row_ != i)
+				return false;
+
+			if (tmp->col_ >= this->size_)
+				return false;
+
+			tmp = tmp->right_;
+
+		}
+
+		return true;
+
+	}
+
+public:
+
+	GCC_DIAG_OFF(effc++)
+	struct IteratorBase : public std::iterator<std::input_iterator_tag, size_t> {
+	GCC_DIAG_ON(effc++)
+
+		Element* el_;
+
+		IteratorBase(Element* el) : el_(el) {}
+		~IteratorBase() {}
+
+		bool operator==(const IteratorBase& rhs) { return this->el_ == rhs.el_; }
+		bool operator!=(const IteratorBase& rhs) { return this->el_ != rhs.el_; }
+
+	};
+
+	GCC_DIAG_OFF(effc++)
+	struct ColIterator : public IteratorBase {
+	GCC_DIAG_ON(effc++)
+
+		ColIterator(Element* el) : IteratorBase(el) {}
+
+		ColIterator& operator++() {
+
+			this->el_ = this->el_->down_;
+			return *this;
+
+		}
+
+		ColIterator operator++(int) {
+
+			return ++ColIterator(this->el_);
+
+		}
+
+		const size_t& operator*() const { return this->el_->row_; }
+
+	};
+
+	GCC_DIAG_OFF(effc++)
+	struct RowIterator : public IteratorBase {
+	GCC_DIAG_ON(effc++)
+
+		RowIterator(Element* el) : IteratorBase(el) {}
+
+		RowIterator& operator++() {
+
+			this->el_ = this->el_->right_;
+			return *this;
+
+		}
+
+		RowIterator operator++(int) {
+
+			return ++RowIterator(this->el_);
+
+		}
+
+		const size_t& operator*() const { return this->el_->col_; }
+
+	};
+
+	struct Column {
+
+		Element*& begin_;
+		Element* end_;
+
+		Column(Element*& begin, Element* end) : begin_(begin), end_(end) {}
+
+		ColIterator begin() const { return ColIterator(this->begin_); }
+		ColIterator end() const { return ColIterator(this->end_); }
+
+	};
+
+	struct Row {
+
+		Element*& begin_;
+		Element* end_;
+
+		Row(Element*& begin, Element* end) : begin_(begin), end_(end) {}
+
+		RowIterator begin() const { return RowIterator(this->begin_); }
+		RowIterator end() const { return RowIterator(this->end_); }
+
+	};
+
+public:
+
+	SplittingRelation(size_t maxSize) : columns_(maxSize), rows_(maxSize), size_(), allocator_() {}
+
+	~SplittingRelation() {
+
+		for (size_t i = 0; i < this->size_; ++i) {
+
+			auto tmp = this->rows_[i].first;
+
+			while (tmp != this->rows_[i].second->right_) {
+
+				this->allocator_.reclaim(tmp);
+
+				tmp = tmp->right_;
+
+			}
+
+		}
+
+	}
+
+	template <class Index>
+	void init(const Index& index) {
+
+		std::vector<Element*> lastV(index.size());
+
+		for (size_t i = 0; i < index.size(); ++i)
+			lastV[i] = this->colBegin(i);
+
+		for (size_t i = 0; i < index.size(); ++i) {
+
+			auto last = this->rowBegin(i);
+
+			Element* el;
+
+			assert(index[i].size());
+
+			for (auto& j: index[i]) {
+
+				assert(j < index.size());
+
+				el = new Element(i, j);
+				el->up_ = lastV[j];
+				el->left_ = last;
+
+				lastV[j]->down_ = el;
+				lastV[j] = el;
+
+				last->right_ = el;
+				last = el;
+
+			}
+
+			last->right_ = this->rowEnd(i);
+			this->rows_[i].second = last; // last->right_->left_
+
+		}
+
+		this->size_ = index.size();
+
+		for (size_t i = 0; i < index.size(); ++i) {
+
+			lastV[i]->down_ = this->colEnd(i);
+			this->columns_[i].second = lastV[i]; // lastV[i]->down_->up_
+
+			assert(this->checkCol(i));
+			assert(this->checkRow(i));
+
+		}
+
+	}
+
+	size_t split(size_t index) {
+
+		assert(index < this->size_);
+
+		size_t newIndex = this->size_;
+
+		// copy column
+
+		auto el = this->columns_[index].first;
+
+		assert(el);
+
+		auto last = this->colBegin(newIndex);
+
+		while (el != this->colEnd(index)) {
+
+			auto tmp = this->allocator_();
+
+			last->down_ = tmp;
+			tmp->up_ = last;
+
+			assert(el->row_ < this->size_);
+
+			this->rows_[el->row_].second->right_ = tmp;
+			tmp->left_ = this->rows_[el->row_].second;
+			tmp->right_ = this->rowEnd(el->row_);
+			this->rows_[el->row_].second = tmp; // tmp->right_->left_
+
+			tmp->col_ = newIndex;
+			tmp->row_ = el->row_;
+
+			last = tmp;
+
+			el = el->down_;
+
+		}
+
+		// put reflexivity
+
+		el = this->allocator_();
+
+		last->down_ = el;
+		el->up_ = last;
+		el->down_ = this->colEnd(newIndex);
+		this->columns_[newIndex].second = el; // el->down_->up_
+
+		el->right_ = this->rowEnd(newIndex);
+		el->col_ = newIndex;
+		el->row_ = newIndex;
+
+		// copy row
+
+		el = this->rows_[index].first;
+
+		assert(el);
+
+		last = this->rowBegin(newIndex);
+
+		// we have to skip the last one here
+		while (el != this->rows_[index].second) {
+
+			auto tmp = this->allocator_();
+
+			last->right_ = tmp;
+			tmp->left_ = last;
+
+			assert(el->col_ < this->size_);
+
+			this->columns_[el->col_].second->down_ = tmp;
+			tmp->up_ = this->columns_[el->col_].second;
+			tmp->down_ = this->colEnd(el->col_);
+			this->columns_[el->col_].second = tmp; // tmp->down_->up_
+
+			tmp->col_ = el->col_;
+			tmp->row_ = newIndex;
+
+			last = tmp;
+
+			el = el->right_;
+
+		}
+
+		// finish reflexivity
+
+		last->right_ = this->columns_[newIndex].second;
+		this->columns_[newIndex].second->left_ = last;
+
+		this->rows_[newIndex].second = this->columns_[newIndex].second;
+
+		++this->size_;
+
+		assert(this->checkCol(newIndex));
+		assert(this->checkRow(newIndex));
+
+		return newIndex;
+
+	}
+
+	Column column(size_t index) {
+
+		assert(index < this->columns_.size());
+		assert(this->checkCol(index));
+
+		return Column(this->columns_[index].first, this->colEnd(index));
+
+	}
+
+	Row row(size_t index) {
+
+		assert(index < this->rows_.size());
+		assert(this->checkRow(index));
+
+		return Row(this->rows_[index].first, this->rowEnd(index));
+
+	}
+
+	void erase(IteratorBase& iter) {
+
+		auto& el = iter.el_;
+
+		el->up_->down_ = el->down_;
+		el->down_->up_ = el->up_;
+		el->left_->right_ = el->right_;
+		el->right_->left_ = el->left_;
+
+		this->allocator_.reclaim(el);
+
+		assert(this->checkCol(el->col_));
+		assert(this->checkRow(el->row_));
+
+	}
+
+	const size_t& size() const {
+
+		return this->size_;
+
+	}
+
+};
+
+#endif

--- a/include/vata2/simutil/splitting_relation.hh
+++ b/include/vata2/simutil/splitting_relation.hh
@@ -48,31 +48,31 @@ class Vata2::Util::SplittingRelation {
 
 	CachingAllocator<Element> allocator_;
 
-	Element* colBegin(size_t col) {
+	Element* col_begin(size_t col) {
 		return reinterpret_cast<Element*>(
 			reinterpret_cast<char*>(&this->columns_[col].first) - offsetof(Element, down_)
 		);
 	}
 
-	Element* colEnd(size_t col) {
+	Element* col_end(size_t col) {
 		return reinterpret_cast<Element*>(
 			reinterpret_cast<char*>(&this->columns_[col].second) - offsetof(Element, up_)
 		);
 	}
 
-	Element* rowBegin(size_t row) {
+	Element* row_begin(size_t row) {
 		return reinterpret_cast<Element*>(
 			reinterpret_cast<char*>(&this->rows_[row].first) - offsetof(Element, right_)
 		);
 	}
 
-	Element* rowEnd(size_t row) {
+	Element* row_end(size_t row) {
 		return reinterpret_cast<Element*>(
 			reinterpret_cast<char*>(&this->rows_[row].second) - offsetof(Element, left_)
 		);
 	}
 
-	bool checkCol(size_t i) const {
+	bool check_col(size_t i) const {
 
 		assert(i < this->size_);
 
@@ -99,7 +99,7 @@ class Vata2::Util::SplittingRelation {
 
 	}
 
-	bool checkRow(size_t i) const {
+	bool check_row(size_t i) const {
 
 		assert(i < this->size_);
 
@@ -240,11 +240,11 @@ public:
 		std::vector<Element*> lastV(index.size());
 
 		for (size_t i = 0; i < index.size(); ++i)
-			lastV[i] = this->colBegin(i);
+			lastV[i] = this->col_begin(i);
 
 		for (size_t i = 0; i < index.size(); ++i) {
 
-			auto last = this->rowBegin(i);
+			auto last = this->row_begin(i);
 
 			Element* el;
 
@@ -266,7 +266,7 @@ public:
 
 			}
 
-			last->right_ = this->rowEnd(i);
+			last->right_ = this->row_end(i);
 			this->rows_[i].second = last; // last->right_->left_
 
 		}
@@ -275,11 +275,11 @@ public:
 
 		for (size_t i = 0; i < index.size(); ++i) {
 
-			lastV[i]->down_ = this->colEnd(i);
+			lastV[i]->down_ = this->col_end(i);
 			this->columns_[i].second = lastV[i]; // lastV[i]->down_->up_
 
-			assert(this->checkCol(i));
-			assert(this->checkRow(i));
+			assert(this->check_col(i));
+			assert(this->check_row(i));
 
 		}
 
@@ -297,9 +297,9 @@ public:
 
 		assert(el);
 
-		auto last = this->colBegin(newIndex);
+		auto last = this->col_begin(newIndex);
 
-		while (el != this->colEnd(index)) {
+		while (el != this->col_end(index)) {
 
 			auto tmp = this->allocator_();
 
@@ -310,7 +310,7 @@ public:
 
 			this->rows_[el->row_].second->right_ = tmp;
 			tmp->left_ = this->rows_[el->row_].second;
-			tmp->right_ = this->rowEnd(el->row_);
+			tmp->right_ = this->row_end(el->row_);
 			this->rows_[el->row_].second = tmp; // tmp->right_->left_
 
 			tmp->col_ = newIndex;
@@ -328,10 +328,10 @@ public:
 
 		last->down_ = el;
 		el->up_ = last;
-		el->down_ = this->colEnd(newIndex);
+		el->down_ = this->col_end(newIndex);
 		this->columns_[newIndex].second = el; // el->down_->up_
 
-		el->right_ = this->rowEnd(newIndex);
+		el->right_ = this->row_end(newIndex);
 		el->col_ = newIndex;
 		el->row_ = newIndex;
 
@@ -341,7 +341,7 @@ public:
 
 		assert(el);
 
-		last = this->rowBegin(newIndex);
+		last = this->row_begin(newIndex);
 
 		// we have to skip the last one here
 		while (el != this->rows_[index].second) {
@@ -355,7 +355,7 @@ public:
 
 			this->columns_[el->col_].second->down_ = tmp;
 			tmp->up_ = this->columns_[el->col_].second;
-			tmp->down_ = this->colEnd(el->col_);
+			tmp->down_ = this->col_end(el->col_);
 			this->columns_[el->col_].second = tmp; // tmp->down_->up_
 
 			tmp->col_ = el->col_;
@@ -376,8 +376,8 @@ public:
 
 		++this->size_;
 
-		assert(this->checkCol(newIndex));
-		assert(this->checkRow(newIndex));
+		assert(this->check_col(newIndex));
+		assert(this->check_row(newIndex));
 
 		return newIndex;
 
@@ -386,18 +386,18 @@ public:
 	Column column(size_t index) {
 
 		assert(index < this->columns_.size());
-		assert(this->checkCol(index));
+		assert(this->check_col(index));
 
-		return Column(this->columns_[index].first, this->colEnd(index));
+		return Column(this->columns_[index].first, this->col_end(index));
 
 	}
 
 	Row row(size_t index) {
 
 		assert(index < this->rows_.size());
-		assert(this->checkRow(index));
+		assert(this->check_row(index));
 
-		return Row(this->rows_[index].first, this->rowEnd(index));
+		return Row(this->rows_[index].first, this->row_end(index));
 
 	}
 
@@ -412,8 +412,8 @@ public:
 
 		this->allocator_.reclaim(el);
 
-		assert(this->checkCol(el->col_));
-		assert(this->checkRow(el->row_));
+		assert(this->check_col(el->col_));
+		assert(this->check_row(el->row_));
 
 	}
 

--- a/include/vata2/simutil/splitting_relation.hh
+++ b/include/vata2/simutil/splitting_relation.hh
@@ -37,7 +37,7 @@ class Vata2::Util::SplittingRelation {
 		size_t col_;
 		size_t row_;
 
-		Element(size_t row = 0, size_t col = 0) : up_(), down_(), left_(), right_(), col_(col),
+		explicit Element(size_t row = 0, size_t col = 0) : up_(), down_(), left_(), right_(), col_(col),
 			row_(row) {}
 
 	};
@@ -134,11 +134,11 @@ public:
 
 		Element* el_;
 
-		IteratorBase(Element* el) : el_(el) {}
-		~IteratorBase() {}
+		explicit IteratorBase(Element* el) : el_(el) {}
+		~IteratorBase() = default;
 
-		bool operator==(const IteratorBase& rhs) { return this->el_ == rhs.el_; }
-		bool operator!=(const IteratorBase& rhs) { return this->el_ != rhs.el_; }
+		bool operator==(const IteratorBase& rhs) const { return this->el_ == rhs.el_; }
+		bool operator!=(const IteratorBase& rhs) const { return this->el_ != rhs.el_; }
 
 	};
 
@@ -146,7 +146,7 @@ public:
 	struct ColIterator : public IteratorBase {
 	GCC_DIAG_ON(effc++)
 
-		ColIterator(Element* el) : IteratorBase(el) {}
+		explicit ColIterator(Element* el) : IteratorBase(el) {}
 
 		ColIterator& operator++() {
 
@@ -169,7 +169,7 @@ public:
 	struct RowIterator : public IteratorBase {
 	GCC_DIAG_ON(effc++)
 
-		RowIterator(Element* el) : IteratorBase(el) {}
+		explicit RowIterator(Element* el) : IteratorBase(el) {}
 
 		RowIterator& operator++() {
 
@@ -214,7 +214,7 @@ public:
 
 public:
 
-	SplittingRelation(size_t maxSize) : columns_(maxSize), rows_(maxSize), size_(), allocator_() {}
+	explicit SplittingRelation(size_t maxSize) : columns_(maxSize), rows_(maxSize), size_(), allocator_() {}
 
 	~SplittingRelation() {
 
@@ -388,7 +388,7 @@ public:
 		assert(index < this->columns_.size());
 		assert(this->check_col(index));
 
-		return Column(this->columns_[index].first, this->col_end(index));
+		return Column{this->columns_[index].first, this->col_end(index)};
 
 	}
 
@@ -397,7 +397,7 @@ public:
 		assert(index < this->rows_.size());
 		assert(this->check_row(index));
 
-		return Row(this->rows_[index].first, this->row_end(index));
+		return Row{this->rows_[index].first, this->row_end(index)};
 
 	}
 

--- a/include/vata2/simutil/transl_weak.hh
+++ b/include/vata2/simutil/transl_weak.hh
@@ -28,7 +28,7 @@ namespace Vata2
 
 		template <
 			class Cont>
-		class TranslatorWeak2;
+		class __attribute__((unused)) TranslatorWeak2;
 	}
 }
 
@@ -56,14 +56,14 @@ private:  // data members
 
 public:   // methods
 
-	TranslatorWeak(
+    __attribute__((unused)) TranslatorWeak(
 		Container&               container,
 		ResultAllocFuncType      resultAllocFunc) :
 			container_(container),
 			result_alloc_func_(resultAllocFunc)
 	{ }
 
-	virtual ResultType operator()(const InputType& value) override
+	ResultType operator()(const InputType& value) override
 	{
 		std::pair<bool, ResultType> res = this->find_if_known(value);
 		if (res.first)
@@ -79,7 +79,7 @@ public:   // methods
 		}
 	}
 
-	virtual ResultType operator()(const InputType& value) const override
+	ResultType operator()(const InputType& value) const override
 	{
 		std::pair<bool, ResultType> res = this->find_if_known(value);
 		if (res.first)
@@ -117,7 +117,7 @@ template
 <
 	class Cont
 >
-class Vata2::Util::TranslatorWeak2 :
+class __attribute__((unused)) Vata2::Util::TranslatorWeak2 :
 	public AbstractTranslator<typename Cont::key_type, typename Cont::mapped_type>
 {
 private:  // data types
@@ -135,14 +135,14 @@ private:  // data members
 
 public:   // methods
 
-	TranslatorWeak2(
+	__attribute__((unused)) TranslatorWeak2(
 		Container&               container,
 		ResultAllocFuncType      resultAllocFunc) :
 			container_(container),
 			result_alloc_func_(resultAllocFunc)
 	{ }
 
-	virtual ResultType operator()(const InputType& value) override
+	ResultType operator()(const InputType& value) override
 	{
 		auto p = container_.insert(std::make_pair(value, ResultType()));
 
@@ -154,7 +154,7 @@ public:   // methods
 		return p.first->second;
 	}
 
-	virtual ResultType operator()(const InputType& value) const override
+	ResultType operator()(const InputType& value) const override
 	{
 		typename Container::const_iterator itCont;
 		if ((itCont = container_.find(value)) != container_.end())
@@ -167,7 +167,7 @@ public:   // methods
 		}
 	}
 
-	const Container& get_container() const
+    __attribute__((unused)) const Container& get_container() const
 	{
 		return container_;
 	}

--- a/include/vata2/simutil/transl_weak.hh
+++ b/include/vata2/simutil/transl_weak.hh
@@ -1,0 +1,176 @@
+/*****************************************************************************
+ *  VATA Tree Automata Library
+ *
+ *  Copyright (c) 2011  Ondra Lengal <ilengal@fit.vutbr.cz>
+ *
+ *  Description:
+ *    The header file of the weak translator class.
+ *
+ *****************************************************************************/
+
+#ifndef _VATA2_TRANSL_WEAK_HH_
+#define _VATA2_TRANSL_WEAK_HH_
+
+#include <functional>
+
+// VATA headers
+#include <vata2/simutil/vata.hh>
+#include <vata2/simutil/abstract_transl.hh>
+
+
+namespace Vata2
+{
+	namespace Util
+	{
+		template <
+			class Cont>
+		class TranslatorWeak;
+
+		template <
+			class Cont>
+		class TranslatorWeak2;
+	}
+}
+
+/**
+ * @brief  Weak translator
+ *
+ */
+template <
+	class Cont>
+class Vata2::Util::TranslatorWeak :
+	public AbstractTranslator<typename Cont::key_type, typename Cont::mapped_type>
+{
+private:  // data types
+
+	typedef Cont Container;
+	typedef typename Container::key_type InputType;
+	typedef typename Container::mapped_type ResultType;
+
+	typedef std::function<ResultType(InputType)> ResultAllocFuncType;
+
+private:  // data members
+
+	Container& container_;
+	ResultAllocFuncType resultAllocFunc_;
+
+public:   // methods
+
+	TranslatorWeak(
+		Container&               container,
+		ResultAllocFuncType      resultAllocFunc) :
+		container_(container),
+		resultAllocFunc_(resultAllocFunc)
+	{ }
+
+	virtual ResultType operator()(const InputType& value) override
+	{
+		std::pair<bool, ResultType> res = this->FindIfKnown(value);
+		if (res.first)
+		{	// in case the value is known
+			return res.second;
+		}
+		else
+		{	// in case there is no translation for the value
+			ResultType result = resultAllocFunc_(value);
+			container_.insert(std::make_pair(value, result));
+
+			return result;
+		}
+	}
+
+	virtual ResultType operator()(const InputType& value) const override
+	{
+		std::pair<bool, ResultType> res = this->FindIfKnown(value);
+		if (res.first)
+		{	// in case the value is known
+			return res.second;
+		}
+		else
+		{	// in case there is no translation for the value
+			throw std::runtime_error("Cannot insert value into const translator.");
+		}
+	}
+
+	/**
+	 * @brief  Finds the value if it is known by the translator
+	 */
+	std::pair<bool, ResultType> FindIfKnown(const InputType& value) const
+	{
+		typename Container::const_iterator itCont;
+		if ((itCont = container_.find(value)) != container_.end())
+		{	// in case the value is known
+			return std::make_pair(true, itCont->second);
+		}
+		else
+		{	// in case there is no translation for the value
+			return std::make_pair(false, ResultType());
+		}
+	}
+};
+
+/**
+ * @brief  Weak translator (ver 2)
+ *
+ */
+template
+<
+	class Cont
+>
+class Vata2::Util::TranslatorWeak2 :
+	public AbstractTranslator<typename Cont::key_type, typename Cont::mapped_type>
+{
+private:  // data types
+
+	typedef Cont Container;
+	typedef typename Container::key_type InputType;
+	typedef typename Container::mapped_type ResultType;
+
+	typedef std::function<ResultType(const InputType&)> ResultAllocFuncType;
+
+private:  // data members
+
+	Container& container_;
+	ResultAllocFuncType resultAllocFunc_;
+
+public:   // methods
+
+	TranslatorWeak2(
+		Container&               container,
+		ResultAllocFuncType      resultAllocFunc) :
+		container_(container),
+		resultAllocFunc_(resultAllocFunc)
+	{ }
+
+	virtual ResultType operator()(const InputType& value) override
+	{
+		auto p = container_.insert(std::make_pair(value, ResultType()));
+
+		if (p.second)
+		{	// in case there is no translation for the value
+			p.first->second = resultAllocFunc_(p.first->first);
+		}
+
+		return p.first->second;
+	}
+
+	virtual ResultType operator()(const InputType& value) const override
+	{
+		typename Container::const_iterator itCont;
+		if ((itCont = container_.find(value)) != container_.end())
+		{	// in case the value is known
+			return itCont->second;
+		}
+		else
+		{
+			throw std::runtime_error("Cannot insert value into const translator.");
+		}
+	}
+
+	const Container& GetContainer() const
+	{
+		return container_;
+	}
+};
+
+#endif

--- a/include/vata2/simutil/transl_weak.hh
+++ b/include/vata2/simutil/transl_weak.hh
@@ -52,27 +52,27 @@ private:  // data types
 private:  // data members
 
 	Container& container_;
-	ResultAllocFuncType resultAllocFunc_;
+	ResultAllocFuncType result_alloc_func_;
 
 public:   // methods
 
 	TranslatorWeak(
 		Container&               container,
 		ResultAllocFuncType      resultAllocFunc) :
-		container_(container),
-		resultAllocFunc_(resultAllocFunc)
+			container_(container),
+			result_alloc_func_(resultAllocFunc)
 	{ }
 
 	virtual ResultType operator()(const InputType& value) override
 	{
-		std::pair<bool, ResultType> res = this->FindIfKnown(value);
+		std::pair<bool, ResultType> res = this->find_if_known(value);
 		if (res.first)
 		{	// in case the value is known
 			return res.second;
 		}
 		else
 		{	// in case there is no translation for the value
-			ResultType result = resultAllocFunc_(value);
+			ResultType result = result_alloc_func_(value);
 			container_.insert(std::make_pair(value, result));
 
 			return result;
@@ -81,7 +81,7 @@ public:   // methods
 
 	virtual ResultType operator()(const InputType& value) const override
 	{
-		std::pair<bool, ResultType> res = this->FindIfKnown(value);
+		std::pair<bool, ResultType> res = this->find_if_known(value);
 		if (res.first)
 		{	// in case the value is known
 			return res.second;
@@ -95,7 +95,7 @@ public:   // methods
 	/**
 	 * @brief  Finds the value if it is known by the translator
 	 */
-	std::pair<bool, ResultType> FindIfKnown(const InputType& value) const
+	std::pair<bool, ResultType> find_if_known(const InputType& value) const
 	{
 		typename Container::const_iterator itCont;
 		if ((itCont = container_.find(value)) != container_.end())
@@ -131,15 +131,15 @@ private:  // data types
 private:  // data members
 
 	Container& container_;
-	ResultAllocFuncType resultAllocFunc_;
+	ResultAllocFuncType result_alloc_func_;
 
 public:   // methods
 
 	TranslatorWeak2(
 		Container&               container,
 		ResultAllocFuncType      resultAllocFunc) :
-		container_(container),
-		resultAllocFunc_(resultAllocFunc)
+			container_(container),
+			result_alloc_func_(resultAllocFunc)
 	{ }
 
 	virtual ResultType operator()(const InputType& value) override
@@ -148,7 +148,7 @@ public:   // methods
 
 		if (p.second)
 		{	// in case there is no translation for the value
-			p.first->second = resultAllocFunc_(p.first->first);
+			p.first->second = result_alloc_func_(p.first->first);
 		}
 
 		return p.first->second;
@@ -167,7 +167,7 @@ public:   // methods
 		}
 	}
 
-	const Container& GetContainer() const
+	const Container& get_container() const
 	{
 		return container_;
 	}

--- a/include/vata2/simutil/two_way_dict.hh
+++ b/include/vata2/simutil/two_way_dict.hh
@@ -58,8 +58,8 @@ public:   // Public data types
 	typedef T1 Type1;
 	typedef T2 Type2;
 
-	typedef Type1 key_type;
-	typedef Type2 mapped_type;
+    typedef Type1 key_type;
+    typedef Type2 mapped_type;
 
 	typedef Cont1 MapFwdType;
 	typedef Cont2 MapBwdType;
@@ -105,12 +105,7 @@ public:   // Public methods
 		}
 	}
 
-	/**
-	 * @brief  Copy constructor
-	 */
-	TwoWayDict(const TwoWayDict&) = default;
-
-	const Type2& translate_fwd(const Type1& t1) const
+    __attribute__((unused)) const Type2& translate_fwd(const Type1& t1) const
 	{
 		ConstIteratorFwd itFwd;
 		if ((itFwd = fwdmap_.find(t1)) == this->end_fwd())
@@ -142,7 +137,7 @@ public:   // Public methods
 		return fwdmap_.find(t1);
 	}
 
-	ConstIteratorBwd find_bwd(const Type2& t2) const
+    __attribute__((unused)) ConstIteratorBwd find_bwd(const Type2& t2) const
 	{
 		return bwdmap_.find(t2);
 	}
@@ -175,7 +170,7 @@ public:   // Public methods
 		return fwdmap_.begin();
 	}
 
-	ConstIteratorBwd begin_bwd() const
+    __attribute__((unused)) ConstIteratorBwd begin_bwd() const
 	{
 		return bwdmap_.begin();
 	}
@@ -218,7 +213,7 @@ public:   // Public methods
 		return resPair;
 	}
 
-	TwoWayDict Union(
+    __attribute__((unused)) TwoWayDict Union(
 		const TwoWayDict&         rhs) const
 	{
 		TwoWayDict result = *this;
@@ -238,7 +233,7 @@ public:   // Public methods
 		return result;
 	}
 
-	const MapBwdType& get_reverse_map() const
+    __attribute__((unused)) const MapBwdType& get_reverse_map() const
 	{
 		return bwdmap_;
 	}

--- a/include/vata2/simutil/two_way_dict.hh
+++ b/include/vata2/simutil/two_way_dict.hh
@@ -1,0 +1,259 @@
+/*****************************************************************************
+ *  VATA Tree Automata Library
+ *
+ *  Copyright (c) 2011  Ondra Lengal <ilengal@fit.vutbr.cz>
+ *
+ *  Description:
+ *    Header file for a two way dictionary.
+ *
+ *****************************************************************************/
+
+#ifndef _VATA2_TWO_WAY_DICT_
+#define _VATA2_TWO_WAY_DICT_
+
+// VATA headers
+#include <vata2/convert.hh>
+#include <vata2/simutil/vata.hh>
+
+// Standard library headers
+#include <map>
+
+
+namespace Vata2
+{
+	namespace Util
+	{
+		template
+		<
+			typename T1,
+			typename T2,
+			class Cont1,
+			class Cont2
+		>
+		class TwoWayDict;
+	}
+}
+
+
+/**
+ * @brief   Two-way dictionary
+ *
+ * This class can be used as a two-way dictionary for two different types, @p
+ * Type1 and @p Type2
+ *
+ * @tparam  Type1   First type
+ * @tparam  Type2   Second type
+ */
+template
+<
+	typename T1,
+	typename T2,
+	class Cont1 = std::map<T1, T2>,
+	class Cont2 = std::map<T2, T1>
+>
+class Vata2::Util::TwoWayDict
+{
+public:   // Public data types
+
+	typedef T1 Type1;
+	typedef T2 Type2;
+
+	typedef Type1 key_type;
+	typedef Type2 mapped_type;
+
+	typedef Cont1 MapFwdType;
+	typedef Cont2 MapBwdType;
+
+public:   // Public data types
+
+	typedef typename MapFwdType::const_iterator ConstIteratorFwd;
+	typedef typename MapBwdType::const_iterator ConstIteratorBwd;
+
+	typedef typename MapFwdType::const_iterator const_iterator;
+
+private:  // Private data members
+
+	MapFwdType fwdMap_;
+	MapBwdType bwdMap_;
+
+public:   // Public methods
+
+	TwoWayDict() :
+		fwdMap_(),
+		bwdMap_()
+	{ }
+
+
+	/**
+	 * @brief  Constructor from the forward map
+	 *
+	 * This constructor copies the forward map and attempts to infer the backward map.
+	 *
+	 * @param[in]  fwdMap  The forward mapping
+	 */
+	explicit TwoWayDict(const MapFwdType& fwdMap) :
+		fwdMap_(fwdMap),
+		bwdMap_()
+	{
+		for (auto mappingPair : fwdMap_)
+		{
+			if (!bwdMap_.insert(std::make_pair(mappingPair.second, mappingPair.first)).second)
+			{
+				throw std::runtime_error(std::string(__func__) +
+					": failed to construct reverse mapping");
+			}
+		}
+	}
+
+	/**
+	 * @brief  Copy constructor
+	 */
+	TwoWayDict(const TwoWayDict&) = default;
+
+	const Type2& TranslateFwd(const Type1& t1) const
+	{
+		ConstIteratorFwd itFwd;
+		if ((itFwd = fwdMap_.find(t1)) == this->EndFwd())
+		{	// in case the value that should be stored there is not
+			throw std::out_of_range(__func__);
+		}
+
+		return itFwd->second;
+	}
+
+	const Type1& TranslateBwd(const Type2& t2) const
+	{
+		ConstIteratorBwd itBwd;
+		if ((itBwd = bwdMap_.find(t2)) == EndBwd())
+		{	// in case the value that should be stored there is not
+			throw std::out_of_range(__func__);
+		}
+
+		return itBwd->second;
+	}
+
+	const_iterator find(const Type1& t1) const
+	{
+		return this->FindFwd(t1);
+	}
+
+	ConstIteratorFwd FindFwd(const Type1& t1) const
+	{
+		return fwdMap_.find(t1);
+	}
+
+	ConstIteratorBwd FindBwd(const Type2& t2) const
+	{
+		return bwdMap_.find(t2);
+	}
+
+	const Type2& at(const Type1& t1) const
+	{
+		const_iterator it = this->find(t1);
+		if (this->end() == it)
+		{
+			throw std::out_of_range(__func__);
+		}
+		else
+		{
+			return it->second;
+		}
+	}
+
+	const_iterator begin() const
+	{
+		return this->BeginFwd();
+	}
+
+	const_iterator end() const
+	{
+		return this->EndFwd();
+	}
+
+	ConstIteratorFwd BeginFwd() const
+	{
+		return fwdMap_.begin();
+	}
+
+	ConstIteratorBwd BeginBwd() const
+	{
+		return bwdMap_.begin();
+	}
+
+	ConstIteratorFwd EndFwd() const
+	{
+		return fwdMap_.end();
+	}
+
+	ConstIteratorBwd EndBwd() const
+	{
+		return bwdMap_.end();
+	}
+
+	std::pair<ConstIteratorFwd, bool> insert(
+		const std::pair<Type1, Type2>& value)
+	{
+		return this->Insert(value);
+	}
+
+	std::pair<ConstIteratorFwd, bool> Insert(
+		const std::pair<Type1, Type2>&    value)
+	{
+		auto resPair = fwdMap_.insert(value);
+		if (!(resPair.second))
+		{	// in case there is already some forward mapping for given value
+			assert(false);      // fail gracefully
+		}
+
+		if (!(bwdMap_.insert(std::make_pair(value.second, value.first)).second))
+		{	// in case there is already some backward mapping for given value
+			VATA_ERROR("backward mapping for "
+				<< Convert::ToString(value.second)
+				<< " already found: "
+				<< Convert::ToString(bwdMap_.find(value.second)->second));
+
+			assert(false);      // fail gracefully
+		}
+
+		return resPair;
+	}
+
+	TwoWayDict Union(
+		const TwoWayDict&         rhs) const
+	{
+		TwoWayDict result = *this;
+
+		// copy all pairs
+		for (ConstIteratorFwd itRhs = rhs.BeginFwd(); itRhs != rhs.EndFwd(); ++itRhs)
+		{
+			if ((result.fwdMap_.find(itRhs->first) != result.fwdMap_.end()) ||
+				(result.bwdMap_.find(itRhs->second) != result.bwdMap_.end()))
+			{	// in case the first or the second component is already in the dictionary
+				assert(false);    // fail gracefully
+			}
+
+			result.Insert(*itRhs);
+		}
+
+		return result;
+	}
+
+	const MapBwdType& GetReverseMap() const
+	{
+		return bwdMap_;
+	}
+
+	size_t size() const
+	{
+		return fwdMap_.size();
+	}
+
+	friend std::ostream& operator<<(
+		std::ostream&         os,
+		const TwoWayDict&     dict)
+	{
+		return (os << Convert::ToString(dict.fwdMap_));
+	}
+};
+
+#endif

--- a/include/vata2/simutil/two_way_dict.hh
+++ b/include/vata2/simutil/two_way_dict.hh
@@ -73,14 +73,14 @@ public:   // Public data types
 
 private:  // Private data members
 
-	MapFwdType fwdMap_;
-	MapBwdType bwdMap_;
+	MapFwdType fwdmap_;
+	MapBwdType bwdmap_;
 
 public:   // Public methods
 
 	TwoWayDict() :
-		fwdMap_(),
-		bwdMap_()
+		fwdmap_(),
+		bwdmap_()
 	{ }
 
 
@@ -92,12 +92,12 @@ public:   // Public methods
 	 * @param[in]  fwdMap  The forward mapping
 	 */
 	explicit TwoWayDict(const MapFwdType& fwdMap) :
-		fwdMap_(fwdMap),
-		bwdMap_()
+		fwdmap_(fwdMap),
+		bwdmap_()
 	{
-		for (auto mappingPair : fwdMap_)
+		for (auto mappingPair : fwdmap_)
 		{
-			if (!bwdMap_.insert(std::make_pair(mappingPair.second, mappingPair.first)).second)
+			if (!bwdmap_.insert(std::make_pair(mappingPair.second, mappingPair.first)).second)
 			{
 				throw std::runtime_error(std::string(__func__) +
 					": failed to construct reverse mapping");
@@ -110,10 +110,10 @@ public:   // Public methods
 	 */
 	TwoWayDict(const TwoWayDict&) = default;
 
-	const Type2& TranslateFwd(const Type1& t1) const
+	const Type2& translate_fwd(const Type1& t1) const
 	{
 		ConstIteratorFwd itFwd;
-		if ((itFwd = fwdMap_.find(t1)) == this->EndFwd())
+		if ((itFwd = fwdmap_.find(t1)) == this->end_fwd())
 		{	// in case the value that should be stored there is not
 			throw std::out_of_range(__func__);
 		}
@@ -121,10 +121,10 @@ public:   // Public methods
 		return itFwd->second;
 	}
 
-	const Type1& TranslateBwd(const Type2& t2) const
+	const Type1& translate_bwd(const Type2& t2) const
 	{
 		ConstIteratorBwd itBwd;
-		if ((itBwd = bwdMap_.find(t2)) == EndBwd())
+		if ((itBwd = bwdmap_.find(t2)) == end_bwd())
 		{	// in case the value that should be stored there is not
 			throw std::out_of_range(__func__);
 		}
@@ -134,17 +134,17 @@ public:   // Public methods
 
 	const_iterator find(const Type1& t1) const
 	{
-		return this->FindFwd(t1);
+		return this->find_fwd(t1);
 	}
 
-	ConstIteratorFwd FindFwd(const Type1& t1) const
+	ConstIteratorFwd find_fwd(const Type1& t1) const
 	{
-		return fwdMap_.find(t1);
+		return fwdmap_.find(t1);
 	}
 
-	ConstIteratorBwd FindBwd(const Type2& t2) const
+	ConstIteratorBwd find_bwd(const Type2& t2) const
 	{
-		return bwdMap_.find(t2);
+		return bwdmap_.find(t2);
 	}
 
 	const Type2& at(const Type1& t1) const
@@ -162,32 +162,32 @@ public:   // Public methods
 
 	const_iterator begin() const
 	{
-		return this->BeginFwd();
+		return this->begin_fwd();
 	}
 
 	const_iterator end() const
 	{
-		return this->EndFwd();
+		return this->end_fwd();
 	}
 
-	ConstIteratorFwd BeginFwd() const
+	ConstIteratorFwd begin_fwd() const
 	{
-		return fwdMap_.begin();
+		return fwdmap_.begin();
 	}
 
-	ConstIteratorBwd BeginBwd() const
+	ConstIteratorBwd begin_bwd() const
 	{
-		return bwdMap_.begin();
+		return bwdmap_.begin();
 	}
 
-	ConstIteratorFwd EndFwd() const
+	ConstIteratorFwd end_fwd() const
 	{
-		return fwdMap_.end();
+		return fwdmap_.end();
 	}
 
-	ConstIteratorBwd EndBwd() const
+	ConstIteratorBwd end_bwd() const
 	{
-		return bwdMap_.end();
+		return bwdmap_.end();
 	}
 
 	std::pair<ConstIteratorFwd, bool> insert(
@@ -199,18 +199,18 @@ public:   // Public methods
 	std::pair<ConstIteratorFwd, bool> Insert(
 		const std::pair<Type1, Type2>&    value)
 	{
-		auto resPair = fwdMap_.insert(value);
+		auto resPair = fwdmap_.insert(value);
 		if (!(resPair.second))
 		{	// in case there is already some forward mapping for given value
 			assert(false);      // fail gracefully
 		}
 
-		if (!(bwdMap_.insert(std::make_pair(value.second, value.first)).second))
+		if (!(bwdmap_.insert(std::make_pair(value.second, value.first)).second))
 		{	// in case there is already some backward mapping for given value
 			VATA_ERROR("backward mapping for "
 				<< Convert::ToString(value.second)
 				<< " already found: "
-				<< Convert::ToString(bwdMap_.find(value.second)->second));
+				<< Convert::ToString(bwdmap_.find(value.second)->second));
 
 			assert(false);      // fail gracefully
 		}
@@ -224,10 +224,10 @@ public:   // Public methods
 		TwoWayDict result = *this;
 
 		// copy all pairs
-		for (ConstIteratorFwd itRhs = rhs.BeginFwd(); itRhs != rhs.EndFwd(); ++itRhs)
+		for (ConstIteratorFwd itRhs = rhs.begin_fwd(); itRhs != rhs.end_fwd(); ++itRhs)
 		{
-			if ((result.fwdMap_.find(itRhs->first) != result.fwdMap_.end()) ||
-				(result.bwdMap_.find(itRhs->second) != result.bwdMap_.end()))
+			if ((result.fwdmap_.find(itRhs->first) != result.fwdmap_.end()) ||
+				(result.bwdmap_.find(itRhs->second) != result.bwdmap_.end()))
 			{	// in case the first or the second component is already in the dictionary
 				assert(false);    // fail gracefully
 			}
@@ -238,21 +238,21 @@ public:   // Public methods
 		return result;
 	}
 
-	const MapBwdType& GetReverseMap() const
+	const MapBwdType& get_reverse_map() const
 	{
-		return bwdMap_;
+		return bwdmap_;
 	}
 
 	size_t size() const
 	{
-		return fwdMap_.size();
+		return fwdmap_.size();
 	}
 
 	friend std::ostream& operator<<(
 		std::ostream&         os,
 		const TwoWayDict&     dict)
 	{
-		return (os << Convert::ToString(dict.fwdMap_));
+		return (os << Convert::ToString(dict.fwdmap_));
 	}
 };
 

--- a/include/vata2/simutil/vata.hh
+++ b/include/vata2/simutil/vata.hh
@@ -1,0 +1,62 @@
+/*****************************************************************************
+ *  VATA Tree Automata Library
+ *
+ *  Copyright (c) 2011  Ondra Lengal <ilengal@fit.vutbr.cz>
+ *
+ *  Description:
+ *    Header file with global declarations. It contains:
+ *      * macros for easy logging
+ *      * macro for suppressing certain GCC warnings
+ *
+ *****************************************************************************/
+
+#ifndef _VATA2_VATA_SIM_HH_
+#define _VATA2_VATA_SIM_HH_
+
+// Standard library headers
+#include <cassert>
+#include <iostream>
+
+//#define NDEBUG
+
+#ifdef NDEBUG
+	#define DEBUG 0
+#endif
+
+#define VATA_LOG_PREFIX (std::string(__FILE__ ":" + Vata2::Util::Convert::ToString(__LINE__) + ": "))
+
+/// @todo: maybe change logging to something like Boost::Log or Google's logging stuff?
+#define VATA_LOG_MESSAGE(severity, msg) (std::clog << #severity << ": " << (VATA_LOG_PREFIX) << msg << "\n")
+
+#define VATA_DEBUG(msg)    (VATA_LOG_MESSAGE(debug, msg))
+#define VATA_INFO(msg)     (VATA_LOG_MESSAGE(info, msg))
+#define VATA_NOTICE(msg)   (VATA_LOG_MESSAGE(notice, msg))
+#define VATA_WARN(msg)     (VATA_LOG_MESSAGE(warning, msg))
+#define VATA_ERROR(msg)    (VATA_LOG_MESSAGE(error, msg))
+#define VATA_CRIT(msg)     (VATA_LOG_MESSAGE(critical, msg))
+#define VATA_ALERT(msg)    (VATA_LOG_MESSAGE(alert, msg))
+#define VATA_FATAL(msg)    (VATA_LOG_MESSAGE(fatal, msg))
+
+#if defined(__GNUC__) && !defined(__clang__)
+	#if ((__GNUC__ * 100) + __GNUC_MINOR__) >= 402
+		#define GCC_DIAG_STR(s) #s
+		#define GCC_DIAG_JOINSTR(x,y) GCC_DIAG_STR(x ## y)
+		#define GCC_DIAG_DO_PRAGMA(x) _Pragma (#x)
+		#define GCC_DIAG_PRAGMA(x) GCC_DIAG_DO_PRAGMA(GCC diagnostic x)
+		#if ((__GNUC__ * 100) + __GNUC_MINOR__) >= 406
+			#define GCC_DIAG_OFF(x) GCC_DIAG_PRAGMA(push) GCC_DIAG_PRAGMA(ignored GCC_DIAG_JOINSTR(-W,x))
+			#define GCC_DIAG_ON(x) GCC_DIAG_PRAGMA(pop)
+		#else
+			#define GCC_DIAG_OFF(x) GCC_DIAG_PRAGMA(ignored GCC_DIAG_JOINSTR(-W,x))
+			#define GCC_DIAG_ON(x)  GCC_DIAG_PRAGMA(warning GCC_DIAG_JOINSTR(-W,x))
+		#endif
+	#else
+		#define GCC_DIAG_OFF(x)
+		#define GCC_DIAG_ON(x)
+	#endif
+#else
+	#define GCC_DIAG_OFF(x)
+	#define GCC_DIAG_ON(x)
+#endif
+
+#endif

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -41,6 +41,7 @@ add_library(libvata2 STATIC
 # add_library(libvata2 SHARED
 	afa/afa.cc
 	bool-dispatch.cc
+	explicit_lts_sim.cc
 	parser.cc
 	parser-dispatch.cc
 	str-dispatch.cc

--- a/src/explicit_lts_sim.cc
+++ b/src/explicit_lts_sim.cc
@@ -1,0 +1,949 @@
+/*****************************************************************************
+ *  VATA Tree Automata Library
+ *
+ *  Copyright (c) 2011  Jiri Simacek <isimacek@fit.vutbr.cz>
+ *
+ *  Description:
+ *    Source for explicit LTS simulation algorithm.
+ *
+ *****************************************************************************/
+
+// Standard library headers
+#include <cmath>
+#include <ostream>
+#include <vector>
+#include <list>
+#include <cmath>
+#include <algorithm>
+#include <memory>
+#include <unordered_set>
+#include <cstddef>
+
+
+// VATA headers
+#include <vata2/explicit_lts.hh>
+#include <vata2/convert.hh>
+#include <vata2/simutil/binary_relation.hh>
+#include <vata2/simutil/smart_set.hh>
+#include <vata2/simutil/vata.hh>
+
+#include <vata2/simutil/caching_allocator.hh>
+#include <vata2/simutil/shared_counter.hh>
+#include <vata2/simutil/shared_list.hh>
+#include <vata2/simutil/splitting_relation.hh>
+
+
+using Vata2::Util::BinaryRelation;
+using Vata2::Util::SplittingRelation;
+using Vata2::Util::SmartSet;
+using Vata2::Util::CachingAllocator;
+using Vata2::Util::SharedList;
+using Vata2::Util::SharedCounter;
+using Vata2::Util::Convert;
+
+typedef CachingAllocator<std::vector<size_t>> VectorAllocator;
+
+struct SharedListInitF
+{
+	VectorAllocator& allocator_;
+
+	SharedListInitF(VectorAllocator& allocator) : allocator_(allocator) {}
+
+	void operator()(SharedList<std::vector<size_t>>* list)
+	{
+		auto sublist = this->allocator_();
+
+		sublist->clear();
+
+		list->init(sublist);
+	}
+
+};
+
+struct StateListElem
+{
+	size_t index_;
+	struct Block* block_;
+	StateListElem* next_;
+	StateListElem* prev_;
+
+	static void link(
+		StateListElem*   elem1,
+		StateListElem*   elem2)
+	{
+		elem1->next_ = elem2;
+		elem2->prev_ = elem1;
+	}
+
+};
+
+typedef SharedList<std::vector<size_t>> RemoveList;
+typedef CachingAllocator<RemoveList, SharedListInitF> RemoveAllocator;
+
+typedef std::pair<struct Block*, size_t> RemoveQueueElement;
+typedef std::vector<RemoveQueueElement> RemoveQueue;
+
+struct Block
+{
+	size_t index_;
+	StateListElem* states_;
+	size_t size_;
+	std::vector<RemoveList*> remove_;
+	SharedCounter counter_;
+	SmartSet inset_;
+	std::vector<StateListElem*> tmp_;
+
+protected:
+
+	Block(const Block&);
+
+	Block& operator=(const Block&);
+
+public:
+
+	Block(
+		const Vata2::ExplicitLTS&         lts,
+		size_t                           index,
+		StateListElem*                   states,
+		size_t                           size,
+		const SharedCounter::Key&        key,
+		const SharedCounter::LabelMap&   labelMap,
+		const size_t&                    rowSize,
+		SharedCounter::Allocator& allocator) :
+		index_(index),
+		states_(states),
+		size_(size),
+		remove_(lts.labels()),
+		counter_(key, lts.states(), labelMap, rowSize, allocator),
+		inset_(lts.labels()), tmp_()
+	{
+		do
+		{
+			assert(nullptr != states);
+
+			for (auto& a : lts.bwLabels(states->index_))
+			{
+				this->inset_.add(a);
+			}
+
+			states->block_ = this;
+			states = states->next_;
+		} while (states != this->states_);
+	}
+
+	Block(
+		const Vata2::ExplicitLTS&   lts,
+		Block&                     parent,
+		StateListElem*             states,
+		size_t                     size,
+		size_t                     index) :
+		index_(index),
+		states_(states),
+		size_(size),
+		remove_(lts.labels()),
+		counter_(parent.counter_),
+		inset_(lts.labels()),
+		tmp_()
+	{
+		do
+		{
+			assert(nullptr != states);
+
+			for (auto& a : lts.bwLabels(states->index_))
+			{
+				parent.inset_.removeStrict(a);
+				this->inset_.add(a);
+			}
+
+			states->block_ = this;
+			states = states->next_;
+		} while (states != this->states_);
+	}
+
+	void moveToTmp(StateListElem* elem)
+	{
+		this->tmp_.push_back(elem);
+	}
+
+	static bool checkList(StateListElem* elem, size_t size)
+	{
+		auto first = elem;
+
+		while (size--)
+		{
+			assert(nullptr != elem);
+
+			elem = elem->next_;
+		}
+
+		return elem == first;
+	}
+
+	std::pair<StateListElem*, size_t> trySplit()
+	{
+		assert(this->tmp_.size());
+
+		if (this->tmp_.size() == this->size_)
+		{
+			this->tmp_.clear();
+
+			assert(Block::checkList(this->states_, this->size_));
+
+			return std::make_pair(nullptr, 0);
+		}
+
+		auto last = this->tmp_.back();
+		this->tmp_.pop_back();
+		this->states_ = last->next_;
+		StateListElem::link(last->prev_, last->next_);
+
+		if (this->tmp_.empty())
+		{
+			StateListElem::link(last, last);
+
+			assert(Block::checkList(last, 1));
+			assert(Block::checkList(this->states_, this->size_ - 1));
+
+			--this->size_;
+
+			return std::make_pair(last, 1);
+		}
+
+		auto elem = last;
+
+		for (auto& state : this->tmp_)
+		{
+			this->states_ = state->next_;
+
+			StateListElem::link(state->prev_, state->next_);
+			StateListElem::link(elem, state);
+
+			elem = state;
+		}
+
+		StateListElem::link(elem, last);
+
+		auto size = this->tmp_.size() + 1;
+		this->tmp_.clear();
+
+		assert(size < this->size_);
+
+		this->size_ -= size;
+
+		assert(Block::checkList(last, size));
+		assert(Block::checkList(this->states_, this->size_));
+
+		return std::make_pair(last, size);;
+	}
+
+	SmartSet& inset()
+	{
+		return this->inset_;
+	}
+
+	size_t index() const
+	{
+		return this->index_;
+	}
+
+	friend std::ostream& operator<<(
+		std::ostream&     os,
+		const Block&      block)
+	{
+		assert(block.states_);
+
+		os << block.index_ << " (";
+
+		auto elem = block.states_;
+
+		do
+		{
+			os << " " << elem->index_;
+			elem = elem->next_;
+		} while (elem != block.states_);
+
+		return os << " )";
+	}
+};
+
+class SimulationEngine
+{
+protected:
+
+	template <class T>
+	void makeBlock(
+		const T&   states,
+		size_t     blockIndex)
+	{
+		assert(states.size() > 0);
+
+		auto list = &this->index_[states.back()];
+
+		for (auto& q : states)
+		{
+			StateListElem::link(list, &this->index_[q]);
+
+			list = list->next_;
+			list->index_ = q;
+		}
+
+		this->partition_.push_back(
+			new Block(
+				this->lts_,
+				blockIndex,
+				list,
+				states.size(),
+				this->key_,
+				this->labelMap_,
+				this->rowSize_,
+				this->counterAllocator_
+			)
+		);
+	}
+
+	void enqueueToRemove(
+		Block*   block,
+		size_t   label,
+		size_t   state)
+	{
+		if (RemoveList::append(block->remove_[label], state, this->removeAllocator_))
+		{
+			this->queue_.push_back(std::make_pair(block, label));
+		}
+	}
+
+	template <class T>
+	void buildPre(
+		T&               pre,
+		StateListElem*   states,
+		size_t           label) const
+	{
+		std::vector<bool> blockMask(this->partition_.size(), false);
+
+		auto elem = states;
+
+		do
+		{
+			assert(elem);
+
+			for (auto& q : this->lts_.pre(label)[elem->index_])
+			{
+				auto& block = this->index_[q].block_;
+
+				assert(block);
+
+				if (blockMask[block->index()])
+				{
+					continue;
+				}
+
+				blockMask[block->index()] = true;
+				pre.push_back(block);
+			}
+
+			elem = elem->next_;
+
+		} while (elem != states);
+	}
+
+	template <class T1, class T2>
+	void internalSplit(T1& modifiedBlocks, const T2& remove)
+	{
+		std::vector<bool> blockMask(this->partition_.size(), false);
+
+		for (auto& q : remove)
+		{
+			assert(q < this->index_.size());
+
+			auto& elem = this->index_[q];
+			auto block = elem.block_;
+
+			assert(block);
+
+			block->moveToTmp(&elem);
+
+			assert(block->index() < this->partition_.size());
+
+			if (blockMask[block->index()])
+			{
+				continue;
+			}
+
+			blockMask[block->index()] = true;
+			modifiedBlocks.push_back(block);
+		}
+	}
+
+	template <class T>
+	void fastSplit(const T& remove)
+	{
+		std::vector<Block*> modifiedBlocks;
+		this->internalSplit(modifiedBlocks, remove);
+
+		for (auto& block : modifiedBlocks)
+		{
+			assert(block);
+
+			auto p = block->trySplit();
+
+			if (!p.first)
+			{
+				continue;
+			}
+
+			auto newBlock = new Block(
+				this->lts_, *block, p.first, p.second, this->partition_.size()
+			);
+
+			this->partition_.push_back(newBlock);
+			this->relation_.split(block->index_);
+		}
+	}
+
+	template <class T>
+	void split(
+		std::vector<bool>&   removeMask,
+		const T&             remove)
+	{
+		std::vector<Block*> modifiedBlocks;
+		this->internalSplit(modifiedBlocks, remove);
+
+		for (auto& block : modifiedBlocks)
+		{
+			assert(block);
+
+			auto p = block->trySplit();
+
+			if (!p.first)
+			{
+				removeMask[block->index_] = true;
+
+				continue;
+			}
+
+			auto newBlock = new Block(
+				this->lts_, *block, p.first, p.second, this->partition_.size()
+			);
+
+			this->partition_.push_back(newBlock);
+			this->relation_.split(block->index_);
+			removeMask[newBlock->index_] = true;
+			newBlock->counter_.copyLabels(newBlock->inset_, block->counter_);
+
+			for (auto& a : newBlock->inset_)
+			{
+				if (!block->remove_[a])
+				{
+					continue;
+				}
+
+				this->queue_.push_back(std::make_pair(newBlock, a));
+				newBlock->remove_[a] = block->remove_[a]->copy();
+			}
+		}
+	}
+
+	void processRemove(
+		Block*   block,
+		size_t   label)
+	{
+		assert(nullptr != block);
+
+		auto remove = block->remove_[label];
+		block->remove_[label] = nullptr;
+
+		assert(remove);
+
+		std::vector<Block*> preList;
+		std::vector<bool> removeMask(this->lts_.states());
+		this->buildPre(preList, block->states_, label);
+		this->split(removeMask, *remove);
+
+		remove->unsafeRelease(
+			[this](RemoveList* list){
+				this->vectorAllocator_.reclaim(list->subList());
+				this->removeAllocator_.reclaim(list);
+			}
+		);
+
+		for (auto& b1 : preList)
+		{
+			SplittingRelation::Row row = this->relation_.row(b1->index_);
+
+			for (auto col = row.begin(); col != row.end(); ++col)
+			{
+				if (!removeMask[*col])
+				{
+					continue;
+				}
+
+				assert(b1->index_ != *col);
+				this->relation_.erase(col);
+				auto b2 = this->partition_[*col];
+
+				for (auto a : b2->inset_)
+				{
+					if (!b1->inset_.contains(a))
+					{
+						continue;
+					}
+
+					auto elem = b2->states_;
+
+					do
+					{
+						assert(elem);
+
+						for (auto& pre : this->lts_.pre(a)[elem->index_])
+						{
+							if (!b1->counter_.decr(a, pre))
+							{
+								this->enqueueToRemove(b1, a, pre);
+							}
+						}
+
+						elem = elem->next_;
+					} while (elem != b2->states_);
+				}
+			}
+		}
+	}
+
+	static bool isPartition(
+		const std::vector<std::vector<size_t>>&    part,
+		size_t                                     states)
+	{
+		std::vector<bool> mask(states, false);
+
+		for (auto& cls : part)
+		{
+			for (auto& q : cls)
+			{
+				if (mask[q])
+				{
+					VATA_INFO("state " << q << " appears in more than one block");
+
+					return false;
+				}
+
+				mask[q] = true;
+			}
+		}
+
+		for (size_t i = 0; i < mask.size(); ++i)
+		{
+			if (!mask[i])
+			{
+				VATA_INFO("state " << i << " does not appear anywhere");
+
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	static bool isConsistent(
+		const std::vector<std::vector<size_t>>&   part,
+		const BinaryRelation&                     rel)
+	{
+		if (part.size() != rel.size())
+		{
+			VATA_INFO("partition and relation sizes differ");
+
+			return false;
+		}
+
+		for (size_t i = 0; i < rel.size(); ++i)
+		{
+			if (!rel.get(i, i))
+			{
+				VATA_INFO("relation is not reflexive");
+
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+private:
+
+	const Vata2::ExplicitLTS& lts_;
+
+	size_t rowSize_;
+
+	VectorAllocator vectorAllocator_;
+	RemoveAllocator removeAllocator_;
+	SharedCounter::Allocator counterAllocator_;
+
+	std::vector<Block*> partition_;
+	SplittingRelation relation_;
+
+	std::vector<StateListElem> index_;
+	RemoveQueue queue_;
+	std::vector<size_t> key_;
+	std::vector<std::pair<size_t, size_t>> labelMap_;
+
+	SimulationEngine(const SimulationEngine&);
+
+	SimulationEngine& operator=(const SimulationEngine&);
+
+	static size_t getRowSize(size_t states)
+	{
+		size_t treshold = static_cast<size_t>(std::sqrt(states)) >> 1;
+		size_t rowSize_ = 32;
+
+		while (rowSize_ <= treshold)
+		{
+			rowSize_ <<= 1;
+		}
+
+		// make room for reference counter
+		return rowSize_ - 1;
+	}
+
+public:
+
+	SimulationEngine(
+		const Vata2::ExplicitLTS& lts) :
+		lts_(lts),
+		rowSize_(SimulationEngine::getRowSize(lts.states())),
+		vectorAllocator_(),
+		removeAllocator_(SharedListInitF(vectorAllocator_)),
+		counterAllocator_(rowSize_ + 1),
+		partition_(),
+		relation_(lts.states()),
+		index_(lts.states()),
+		queue_(),
+		key_(),
+		labelMap_()
+	{
+		assert(this->index_.size());
+	}
+
+	~SimulationEngine()
+	{
+		for (auto& block : this->partition_)
+		{
+			delete block;
+		}
+	}
+
+	void init(
+		const std::vector<std::vector<size_t>>&   partition,
+		const BinaryRelation&                     relation)
+	{
+		assert(SimulationEngine::isPartition(partition, this->lts_.states()));
+		assert(SimulationEngine::isConsistent(partition, relation));
+
+		// build counter maps
+		std::vector<SmartSet> delta1;
+		this->lts_.buildDelta1(delta1);
+
+		this->key_.resize(this->lts_.labels()*this->lts_.states(), static_cast<size_t>(-1));
+		this->labelMap_.resize(this->lts_.labels());
+
+		size_t x = 0;
+
+		for (size_t a = 0; a < this->lts_.labels(); ++a)
+		{
+			this->labelMap_[a].first = x / this->rowSize_;
+			this->labelMap_[a].second =
+				(x + delta1[a].size() - 1) / this->rowSize_ + ((delta1[a].size())?(1):(0));
+
+			for (auto& q : delta1[a])
+			{
+				this->key_[a*this->lts_.states() + q] = x++;
+			}
+		}
+
+		// initilize patition-relation
+		for (size_t i = 0; i < partition.size(); ++i)
+		{
+			this->makeBlock(partition[i], i);
+		}
+
+		BinaryRelation::IndexType index;
+		relation.buildIndex(index);
+		this->relation_.init(index);
+
+		// make initial refinement
+		for (size_t a = 0; a < this->lts_.labels(); ++a)
+		{
+			this->fastSplit(delta1[a]);
+		}
+
+		assert(this->relation_.size() == this->partition_.size());
+
+		// prune relation
+		std::vector<std::vector<size_t>> pre(this->partition_.size());
+		std::vector<std::vector<bool>> noPreMask(
+			this->lts_.labels(), std::vector<bool>(this->partition_.size())
+		);
+
+		for (auto& block : this->partition_)
+		{
+			auto elem = block->states_;
+
+			do
+			{
+				for (size_t a = 0; a < this->lts_.labels(); ++a)
+				{
+					delta1[a].contains(elem->index_)
+						? (pre[block->index_].push_back(a), true)
+						: (noPreMask[a][block->index_] = true);
+				}
+
+				elem = elem->next_;
+			} while (elem != block->states_);
+		}
+
+		for (auto& b1 : this->partition_)
+		{
+			auto row = this->relation_.row(b1->index_);
+
+			for (auto& a : pre[b1->index_])
+			{
+				for (auto col = row.begin(); col != row.end(); ++col)
+				{
+					assert(a < noPreMask.size());
+					assert(*col < noPreMask[a].size());
+
+					if (!noPreMask[a][*col])
+					{
+						continue;
+					}
+
+					assert(b1->index_ != *col);
+
+					this->relation_.erase(col);
+				}
+			}
+		}
+
+		// initialize counters
+		SmartSet s;
+
+		for (auto& b1 : this->partition_)
+		{
+			auto row = this->relation_.row(b1->index_);
+			std::vector<bool> relatedBlocks(this->partition_.size());
+
+			for (auto& col : row)
+			{
+				relatedBlocks[col] = true;
+			}
+
+			size_t size = 0;
+
+			for (auto& a : b1->inset())
+			{
+				size = std::max(size, this->labelMap_[a].second);
+			}
+
+			b1->counter_.resize(size);
+
+			for (auto& a : b1->inset())
+			{
+				for (auto q : delta1[a])
+				{
+					size_t count = 0;
+
+					for (auto r : this->lts_.post(a)[q])
+					{
+						if (relatedBlocks[this->index_[r].block_->index_])
+						{
+							++count;
+						}
+					}
+
+					if (count)
+					{
+						b1->counter_.set(a, q, count);
+					}
+				}
+
+				s.assignFlat(delta1[a]);
+
+				for (auto& col : row)
+				{
+					auto b2 = this->partition_[col];
+					auto elem = b2->states_;
+
+					do
+					{
+						for (auto& q : this->lts_.pre(a)[elem->index_])
+						{
+							s.remove(q);
+						}
+
+						elem = elem->next_;
+					} while (elem != b2->states_);
+				}
+
+				if (s.empty())
+				{
+					continue;
+				}
+
+				b1->remove_[a] = new RemoveList(new std::vector<size_t>(s.begin(), s.end()));
+				this->queue_.push_back(std::make_pair(b1, a));
+
+				assert(s.size() == b1->remove_[a]->subList()->size());
+			}
+
+			b1->counter_.init();
+		}
+	}
+
+	void run()
+	{
+		while (!this->queue_.empty())
+		{
+			std::pair<Block*, size_t> tmp(this->queue_.back());
+			this->queue_.pop_back();
+			this->processRemove(tmp.first, tmp.second);
+		}
+	}
+
+	void buildResult(
+		BinaryRelation&    result,
+		size_t             size) const
+	{
+		result.resize(size);
+
+		std::vector<std::vector<size_t>> tmp(this->partition_.size());
+
+		for (size_t i = 0; i < this->partition_.size(); ++i)
+		{
+			auto elem = this->partition_[i]->states_;
+
+			do
+			{
+				assert(elem);
+
+				if (elem->index_ < size)
+				{
+					tmp[i].push_back(elem->index_);
+				}
+
+				elem = elem->next_;
+
+			} while (elem != this->partition_[i]->states_);
+		}
+
+		for (size_t i = 0; i < this->relation_.size(); ++i)
+		{
+			for (auto j : const_cast<SplittingRelation*>(&this->relation_)->row(i))
+			{
+				for (auto& r : tmp[i])
+				{
+					for (auto& s : tmp[j])
+					{
+						result.set(r, s, true);
+					}
+				}
+			}
+		}
+	}
+
+	friend std::ostream& operator<<(
+		std::ostream&              os,
+		const SimulationEngine&    engine)
+	{
+		os << "partition: " << std::endl;
+
+		for (auto& block : engine.partition_)
+		{
+			os << *block;
+		}
+
+		BinaryRelation relation;
+
+		engine.buildResult(relation, engine.partition_.size());
+
+		return os << "relation:" << std::endl << relation;
+	}
+};
+
+BinaryRelation Vata2::ExplicitLTS::computeSimulation(
+	const std::vector<std::vector<size_t>>&   partition,
+	const BinaryRelation&                     relation,
+	size_t                                    outputSize)
+{
+	if (0 == outputSize)
+	{
+		return BinaryRelation();
+	}
+
+	SimulationEngine engine(*this);
+
+	engine.init(partition, relation);
+	engine.run();
+
+	BinaryRelation result;
+
+	engine.buildResult(result, outputSize);
+
+	return result;
+}
+
+
+BinaryRelation Vata2::ExplicitLTS::computeSimulation(
+	size_t   outputSize)
+{
+	std::vector<std::vector<size_t>> partition(1);
+
+	for (size_t i = 0; i < this->states_; ++i)
+	{
+		partition[0].push_back(i);
+	}
+
+	return this->computeSimulation(
+		partition, Util::BinaryRelation(1, true), outputSize
+	);
+}
+
+
+BinaryRelation Vata2::ExplicitLTS::computeSimulation()
+{
+	return this->computeSimulation(this->states_);
+}
+
+
+void Vata2::ExplicitLTS::add_transition(
+	size_t   q,
+	size_t   a,
+	size_t   r)
+{
+	if (a >= this->data_.size())
+	{
+		this->data_.resize(a + 1);
+	}
+
+	if (q >= this->data_[a].first.size())
+	{
+		if (q >= this->states_)
+		{
+			this->states_ = q + 1;
+		}
+
+		this->data_[a].first.resize(q + 1);
+	}
+
+	if (r >= this->data_[a].second.size())
+	{
+		if (r >= this->states_)
+		{
+			this->states_ = r + 1;
+		}
+
+		this->data_[a].second.resize(r + 1);
+	}
+
+	this->data_[a].first[q].push_back(r);
+	this->data_[a].second[r].push_back(q);
+
+	++this->transitions_;
+}

--- a/src/explicit_lts_sim.cc
+++ b/src/explicit_lts_sim.cc
@@ -151,7 +151,7 @@ public:
 
 			for (auto& a : lts.bw_labels(states->index_))
 			{
-				parent.inset_.removeStrict(a);
+				parent.inset_.remove_strict(a);
 				this->inset_.add(a);
 			}
 
@@ -428,7 +428,7 @@ protected:
 			this->partition_.push_back(newBlock);
 			this->relation_.split(block->index_);
 			removeMask[newBlock->index_] = true;
-			newBlock->counter_.copyLabels(newBlock->inset_, block->counter_);
+			newBlock->counter_.copy_labels(newBlock->inset_, block->counter_);
 
 			for (auto& a : newBlock->inset_)
 			{
@@ -456,15 +456,15 @@ protected:
 
 		std::vector<Block*> preList;
 		std::vector<bool> removeMask(this->lts_.states());
-        this->build_pre(preList, block->states_, label);
+		this->build_pre(preList, block->states_, label);
 		this->split(removeMask, *remove);
 
-		remove->unsafeRelease(
-			[this](RemoveList* list){
-				this->vector_allocator_.reclaim(list->subList());
-				this->remove_allocator_.reclaim(list);
-			}
-		);
+		remove->unsafe_release(
+		[this](RemoveList *list) {
+					this->vector_allocator_.reclaim(list->sublist());
+					this->remove_allocator_.reclaim(list);
+				 }
+        );
 
 		for (auto& b1 : preList)
 		{
@@ -665,7 +665,7 @@ public:
 		}
 
 		BinaryRelation::IndexType index;
-		relation.buildIndex(index);
+		relation.build_index(index);
 		this->relation_.init(index);
 
 		// make initial refinement
@@ -764,7 +764,7 @@ public:
 					}
 				}
 
-				s.assignFlat(delta1[a]);
+				s.assign_flat(delta1[a]);
 
 				for (auto& col : row)
 				{
@@ -790,7 +790,7 @@ public:
 				b1->remove_[a] = new RemoveList(new std::vector<size_t>(s.begin(), s.end()));
 				this->queue_.push_back(std::make_pair(b1, a));
 
-				assert(s.size() == b1->remove_[a]->subList()->size());
+				assert(s.size() == b1->remove_[a]->sublist()->size());
 			}
 
 			b1->counter_.init();

--- a/src/explicit_lts_sim.cc
+++ b/src/explicit_lts_sim.cc
@@ -12,12 +12,8 @@
 #include <cmath>
 #include <ostream>
 #include <vector>
-#include <list>
-#include <cmath>
 #include <algorithm>
 #include <memory>
-#include <unordered_set>
-#include <cstddef>
 
 
 // VATA headers
@@ -47,7 +43,7 @@ struct SharedListInitF
 {
 	VectorAllocator& allocator_;
 
-	SharedListInitF(VectorAllocator& allocator) : allocator_(allocator) {}
+	explicit SharedListInitF(VectorAllocator& allocator) : allocator_(allocator) {}
 
 	void operator()(SharedList<std::vector<size_t>>* list)
 	{
@@ -92,12 +88,6 @@ struct Block
 	SharedCounter counter_;
 	SmartSet inset_;
 	std::vector<StateListElem*> tmp_;
-
-protected:
-
-	Block(const Block&);
-
-	Block& operator=(const Block&);
 
 public:
 
@@ -181,7 +171,7 @@ public:
 
 	std::pair<StateListElem*, size_t> try_split()
 	{
-		assert(this->tmp_.size());
+		assert(!this->tmp_.empty());
 
 		if (this->tmp_.size() == this->size_)
 		{
@@ -233,7 +223,7 @@ public:
 		assert(Block::check_list(last, size));
 		assert(Block::check_list(this->states_, this->size_));
 
-		return std::make_pair(last, size);;
+		return std::make_pair(last, size);
 	}
 
 	SmartSet& inset()
@@ -585,10 +575,6 @@ private:
 	std::vector<size_t> key_;
 	std::vector<std::pair<size_t, size_t>> label_map_;
 
-	SimulationEngine(const SimulationEngine&);
-
-	SimulationEngine& operator=(const SimulationEngine&);
-
 	static size_t get_row_size(size_t states)
 	{
 		size_t treshold = static_cast<size_t>(std::sqrt(states)) >> 1;
@@ -605,7 +591,7 @@ private:
 
 public:
 
-	SimulationEngine(
+	explicit SimulationEngine(
 		const Vata2::ExplicitLTS& lts) :
             lts_(lts),
             row_size_(SimulationEngine::get_row_size(lts.states())),
@@ -619,7 +605,7 @@ public:
             key_(),
             label_map_()
 	{
-		assert(this->index_.size());
+		assert(!this->index_.empty());
 	}
 
 	~SimulationEngine()
@@ -650,7 +636,7 @@ public:
 		{
 			this->label_map_[a].first = x / this->row_size_;
 			this->label_map_[a].second =
-				(x + delta1[a].size() - 1) / this->row_size_ + ((delta1[a].size()) ? (1) : (0));
+				(x + delta1[a].size() - 1) / this->row_size_ + ((!delta1[a].empty()) ? (1) : (0));
 
 			for (auto& q : delta1[a])
 			{
@@ -874,7 +860,7 @@ BinaryRelation Vata2::ExplicitLTS::compute_simulation(
 {
 	if (0 == outputSize)
 	{
-		return BinaryRelation();
+		return BinaryRelation{};
 	}
 
 	SimulationEngine engine(*this);

--- a/src/explicit_lts_sim.cc
+++ b/src/explicit_lts_sim.cc
@@ -121,7 +121,7 @@ public:
 		{
 			assert(nullptr != states);
 
-			for (auto& a : lts.bwLabels(states->index_))
+			for (auto& a : lts.bw_labels(states->index_))
 			{
 				this->inset_.add(a);
 			}
@@ -149,7 +149,7 @@ public:
 		{
 			assert(nullptr != states);
 
-			for (auto& a : lts.bwLabels(states->index_))
+			for (auto& a : lts.bw_labels(states->index_))
 			{
 				parent.inset_.removeStrict(a);
 				this->inset_.add(a);
@@ -160,12 +160,12 @@ public:
 		} while (states != this->states_);
 	}
 
-	void moveToTmp(StateListElem* elem)
+	void move_to_tmp(StateListElem* elem)
 	{
 		this->tmp_.push_back(elem);
 	}
 
-	static bool checkList(StateListElem* elem, size_t size)
+	static bool check_list(StateListElem* elem, size_t size)
 	{
 		auto first = elem;
 
@@ -179,7 +179,7 @@ public:
 		return elem == first;
 	}
 
-	std::pair<StateListElem*, size_t> trySplit()
+	std::pair<StateListElem*, size_t> try_split()
 	{
 		assert(this->tmp_.size());
 
@@ -187,7 +187,7 @@ public:
 		{
 			this->tmp_.clear();
 
-			assert(Block::checkList(this->states_, this->size_));
+			assert(Block::check_list(this->states_, this->size_));
 
 			return std::make_pair(nullptr, 0);
 		}
@@ -201,8 +201,8 @@ public:
 		{
 			StateListElem::link(last, last);
 
-			assert(Block::checkList(last, 1));
-			assert(Block::checkList(this->states_, this->size_ - 1));
+			assert(Block::check_list(last, 1));
+			assert(Block::check_list(this->states_, this->size_ - 1));
 
 			--this->size_;
 
@@ -230,8 +230,8 @@ public:
 
 		this->size_ -= size;
 
-		assert(Block::checkList(last, size));
-		assert(Block::checkList(this->states_, this->size_));
+		assert(Block::check_list(last, size));
+		assert(Block::check_list(this->states_, this->size_));
 
 		return std::make_pair(last, size);;
 	}
@@ -271,7 +271,7 @@ class SimulationEngine
 protected:
 
 	template <class T>
-	void makeBlock(
+	void make_block(
 		const T&   states,
 		size_t     blockIndex)
 	{
@@ -294,26 +294,26 @@ protected:
 				list,
 				states.size(),
 				this->key_,
-				this->labelMap_,
-				this->rowSize_,
-				this->counterAllocator_
+				this->label_map_,
+				this->row_size_,
+				this->counter_allocator_
 			)
 		);
 	}
 
-	void enqueueToRemove(
+	void enqueue_to_remove(
 		Block*   block,
 		size_t   label,
 		size_t   state)
 	{
-		if (RemoveList::append(block->remove_[label], state, this->removeAllocator_))
+		if (RemoveList::append(block->remove_[label], state, this->remove_allocator_))
 		{
 			this->queue_.push_back(std::make_pair(block, label));
 		}
 	}
 
 	template <class T>
-	void buildPre(
+	void build_pre(
 		T&               pre,
 		StateListElem*   states,
 		size_t           label) const
@@ -347,7 +347,7 @@ protected:
 	}
 
 	template <class T1, class T2>
-	void internalSplit(T1& modifiedBlocks, const T2& remove)
+	void internal_split(T1& modifiedBlocks, const T2& remove)
 	{
 		std::vector<bool> blockMask(this->partition_.size(), false);
 
@@ -360,7 +360,7 @@ protected:
 
 			assert(block);
 
-			block->moveToTmp(&elem);
+            block->move_to_tmp(&elem);
 
 			assert(block->index() < this->partition_.size());
 
@@ -375,16 +375,16 @@ protected:
 	}
 
 	template <class T>
-	void fastSplit(const T& remove)
+	void fast_split(const T& remove)
 	{
 		std::vector<Block*> modifiedBlocks;
-		this->internalSplit(modifiedBlocks, remove);
+        this->internal_split(modifiedBlocks, remove);
 
 		for (auto& block : modifiedBlocks)
 		{
 			assert(block);
 
-			auto p = block->trySplit();
+			auto p = block->try_split();
 
 			if (!p.first)
 			{
@@ -406,13 +406,13 @@ protected:
 		const T&             remove)
 	{
 		std::vector<Block*> modifiedBlocks;
-		this->internalSplit(modifiedBlocks, remove);
+        this->internal_split(modifiedBlocks, remove);
 
 		for (auto& block : modifiedBlocks)
 		{
 			assert(block);
 
-			auto p = block->trySplit();
+			auto p = block->try_split();
 
 			if (!p.first)
 			{
@@ -443,7 +443,7 @@ protected:
 		}
 	}
 
-	void processRemove(
+	void process_remove(
 		Block*   block,
 		size_t   label)
 	{
@@ -456,13 +456,13 @@ protected:
 
 		std::vector<Block*> preList;
 		std::vector<bool> removeMask(this->lts_.states());
-		this->buildPre(preList, block->states_, label);
+        this->build_pre(preList, block->states_, label);
 		this->split(removeMask, *remove);
 
 		remove->unsafeRelease(
 			[this](RemoveList* list){
-				this->vectorAllocator_.reclaim(list->subList());
-				this->removeAllocator_.reclaim(list);
+				this->vector_allocator_.reclaim(list->subList());
+				this->remove_allocator_.reclaim(list);
 			}
 		);
 
@@ -498,7 +498,7 @@ protected:
 						{
 							if (!b1->counter_.decr(a, pre))
 							{
-								this->enqueueToRemove(b1, a, pre);
+                                this->enqueue_to_remove(b1, a, pre);
 							}
 						}
 
@@ -509,7 +509,7 @@ protected:
 		}
 	}
 
-	static bool isPartition(
+	static bool is_partition(
 		const std::vector<std::vector<size_t>>&    part,
 		size_t                                     states)
 	{
@@ -543,7 +543,7 @@ protected:
 		return true;
 	}
 
-	static bool isConsistent(
+	static bool is_consistent(
 		const std::vector<std::vector<size_t>>&   part,
 		const BinaryRelation&                     rel)
 	{
@@ -571,11 +571,11 @@ private:
 
 	const Vata2::ExplicitLTS& lts_;
 
-	size_t rowSize_;
+	size_t row_size_;
 
-	VectorAllocator vectorAllocator_;
-	RemoveAllocator removeAllocator_;
-	SharedCounter::Allocator counterAllocator_;
+	VectorAllocator vector_allocator_;
+	RemoveAllocator remove_allocator_;
+	SharedCounter::Allocator counter_allocator_;
 
 	std::vector<Block*> partition_;
 	SplittingRelation relation_;
@@ -583,13 +583,13 @@ private:
 	std::vector<StateListElem> index_;
 	RemoveQueue queue_;
 	std::vector<size_t> key_;
-	std::vector<std::pair<size_t, size_t>> labelMap_;
+	std::vector<std::pair<size_t, size_t>> label_map_;
 
 	SimulationEngine(const SimulationEngine&);
 
 	SimulationEngine& operator=(const SimulationEngine&);
 
-	static size_t getRowSize(size_t states)
+	static size_t get_row_size(size_t states)
 	{
 		size_t treshold = static_cast<size_t>(std::sqrt(states)) >> 1;
 		size_t rowSize_ = 32;
@@ -607,17 +607,17 @@ public:
 
 	SimulationEngine(
 		const Vata2::ExplicitLTS& lts) :
-		lts_(lts),
-		rowSize_(SimulationEngine::getRowSize(lts.states())),
-		vectorAllocator_(),
-		removeAllocator_(SharedListInitF(vectorAllocator_)),
-		counterAllocator_(rowSize_ + 1),
-		partition_(),
-		relation_(lts.states()),
-		index_(lts.states()),
-		queue_(),
-		key_(),
-		labelMap_()
+            lts_(lts),
+            row_size_(SimulationEngine::get_row_size(lts.states())),
+            vector_allocator_(),
+            remove_allocator_(SharedListInitF(vector_allocator_)),
+            counter_allocator_(row_size_ + 1),
+            partition_(),
+            relation_(lts.states()),
+            index_(lts.states()),
+            queue_(),
+            key_(),
+            label_map_()
 	{
 		assert(this->index_.size());
 	}
@@ -634,23 +634,23 @@ public:
 		const std::vector<std::vector<size_t>>&   partition,
 		const BinaryRelation&                     relation)
 	{
-		assert(SimulationEngine::isPartition(partition, this->lts_.states()));
-		assert(SimulationEngine::isConsistent(partition, relation));
+		assert(SimulationEngine::is_partition(partition, this->lts_.states()));
+		assert(SimulationEngine::is_consistent(partition, relation));
 
 		// build counter maps
 		std::vector<SmartSet> delta1;
-		this->lts_.buildDelta1(delta1);
+        this->lts_.build_delta1(delta1);
 
 		this->key_.resize(this->lts_.labels()*this->lts_.states(), static_cast<size_t>(-1));
-		this->labelMap_.resize(this->lts_.labels());
+		this->label_map_.resize(this->lts_.labels());
 
 		size_t x = 0;
 
 		for (size_t a = 0; a < this->lts_.labels(); ++a)
 		{
-			this->labelMap_[a].first = x / this->rowSize_;
-			this->labelMap_[a].second =
-				(x + delta1[a].size() - 1) / this->rowSize_ + ((delta1[a].size())?(1):(0));
+			this->label_map_[a].first = x / this->row_size_;
+			this->label_map_[a].second =
+				(x + delta1[a].size() - 1) / this->row_size_ + ((delta1[a].size()) ? (1) : (0));
 
 			for (auto& q : delta1[a])
 			{
@@ -661,7 +661,7 @@ public:
 		// initilize patition-relation
 		for (size_t i = 0; i < partition.size(); ++i)
 		{
-			this->makeBlock(partition[i], i);
+            this->make_block(partition[i], i);
 		}
 
 		BinaryRelation::IndexType index;
@@ -671,7 +671,7 @@ public:
 		// make initial refinement
 		for (size_t a = 0; a < this->lts_.labels(); ++a)
 		{
-			this->fastSplit(delta1[a]);
+            this->fast_split(delta1[a]);
 		}
 
 		assert(this->relation_.size() == this->partition_.size());
@@ -739,7 +739,7 @@ public:
 
 			for (auto& a : b1->inset())
 			{
-				size = std::max(size, this->labelMap_[a].second);
+				size = std::max(size, this->label_map_[a].second);
 			}
 
 			b1->counter_.resize(size);
@@ -803,11 +803,11 @@ public:
 		{
 			std::pair<Block*, size_t> tmp(this->queue_.back());
 			this->queue_.pop_back();
-			this->processRemove(tmp.first, tmp.second);
+            this->process_remove(tmp.first, tmp.second);
 		}
 	}
 
-	void buildResult(
+	void build_result(
 		BinaryRelation&    result,
 		size_t             size) const
 	{
@@ -861,13 +861,13 @@ public:
 
 		BinaryRelation relation;
 
-		engine.buildResult(relation, engine.partition_.size());
+        engine.build_result(relation, engine.partition_.size());
 
 		return os << "relation:" << std::endl << relation;
 	}
 };
 
-BinaryRelation Vata2::ExplicitLTS::computeSimulation(
+BinaryRelation Vata2::ExplicitLTS::compute_simulation(
 	const std::vector<std::vector<size_t>>&   partition,
 	const BinaryRelation&                     relation,
 	size_t                                    outputSize)
@@ -884,13 +884,13 @@ BinaryRelation Vata2::ExplicitLTS::computeSimulation(
 
 	BinaryRelation result;
 
-	engine.buildResult(result, outputSize);
+    engine.build_result(result, outputSize);
 
 	return result;
 }
 
 
-BinaryRelation Vata2::ExplicitLTS::computeSimulation(
+BinaryRelation Vata2::ExplicitLTS::compute_simulation(
 	size_t   outputSize)
 {
 	std::vector<std::vector<size_t>> partition(1);
@@ -900,15 +900,15 @@ BinaryRelation Vata2::ExplicitLTS::computeSimulation(
 		partition[0].push_back(i);
 	}
 
-	return this->computeSimulation(
-		partition, Util::BinaryRelation(1, true), outputSize
-	);
+	return this->compute_simulation(
+            partition, Util::BinaryRelation(1, true), outputSize
+    );
 }
 
 
-BinaryRelation Vata2::ExplicitLTS::computeSimulation()
+BinaryRelation Vata2::ExplicitLTS::compute_simulation()
 {
-	return this->computeSimulation(this->states_);
+	return this->compute_simulation(this->states_);
 }
 
 

--- a/src/nfa/nfa.cc
+++ b/src/nfa/nfa.cc
@@ -51,7 +51,7 @@ namespace {
         receivingSet.insert(addedSet);
     }
 
-    Vata2::Util::BinaryRelation compute_simulation(const Nfa& aut) {
+    Vata2::Util::BinaryRelation compute_fw_direct_simulation(const Nfa& aut) {
         Vata2::ExplicitLTS LTSforSimulation;
         Symbol maxSymbol = 0;
         const size_t state_num = aut.get_num_of_states();
@@ -892,10 +892,16 @@ Vata2::Util::BinaryRelation Vata2::Nfa::compute_relation(const Nfa& aut, const S
                                  " requires setting the \"relation\" key in the \"params\" argument; "
                                  "received: " + std::to_string(params));
     }
+    if (!haskey(params, "direction")) {
+        throw std::runtime_error(std::to_string(__func__) +
+                                 " requires setting the \"direction\" key in the \"params\" argument; "
+                                 "received: " + std::to_string(params));
+    }
 
     const std::string& relation = params.at("relation");
-    if ("simulation" == relation) {
-        return compute_simulation(aut);
+    const std::string& direction = params.at("direction");
+    if ("simulation" == relation && direction == "forward") {
+        return compute_fw_direct_simulation(aut);
     }
     else {
         throw std::runtime_error(std::to_string(__func__) +

--- a/src/nfa/nfa.cc
+++ b/src/nfa/nfa.cc
@@ -22,6 +22,7 @@
 // VATA headers
 #include <vata2/nfa.hh>
 #include <vata2/util.hh>
+#include <vata2/explicit_lts.hh>
 
 using std::tie;
 

--- a/src/nfa/nfa.cc
+++ b/src/nfa/nfa.cc
@@ -882,7 +882,7 @@ Vata2::Util::BinaryRelation Vata2::Nfa::compute_simulation(const Nfa& aut) {
     }
 
     LTSforSimulation.init();
-    return LTSforSimulation.computeSimulation();
+    return LTSforSimulation.compute_simulation();
 }
 
 void Vata2::Nfa::determinize(

--- a/src/nfa/nfa.cc
+++ b/src/nfa/nfa.cc
@@ -860,12 +860,13 @@ void Vata2::Nfa::intersection(Nfa *res, const Nfa &lhs, const Nfa &rhs, ProductM
     }
 }
 
-/*
-Util::BinaryRelation Nfa::computeSimulation() const {
-    VATA::ExplicitLTS LTSforSimulation;
+Vata2::Util::BinaryRelation Vata2::Nfa::compute_simulation(const Nfa& aut) {
+    Vata2::ExplicitLTS LTSforSimulation;
     Symbol maxSymbol = 0;
-    for (State stateFrom = 0; stateFrom < transitionrelation.size(); ++stateFrom) {
-        for (const TransSymbolStates &t : getTransitionsFromState(stateFrom)) {
+    const size_t state_num = aut.get_num_of_states();
+
+    for (State stateFrom = 0; stateFrom < state_num; ++stateFrom) {
+        for (const TransSymbolStates &t : aut.get_transitions_from_state(stateFrom)) {
             for (State stateTo : t.states_to) {
                 LTSforSimulation.add_transition(stateFrom, t.symbol, stateTo);
             }
@@ -876,14 +877,14 @@ Util::BinaryRelation Nfa::computeSimulation() const {
     }
 
     // final states cannot be simulated by nonfinal -> we add new selfloops over final states with new symbol in LTS
-    for (State finalState : finalstates) {
+    for (State finalState : aut.finalstates) {
         LTSforSimulation.add_transition(finalState, maxSymbol + 1, finalState);
     }
 
     LTSforSimulation.init();
     return LTSforSimulation.computeSimulation();
 }
-*/
+
 void Vata2::Nfa::determinize(
         Nfa*        result,
         const Nfa&  aut,

--- a/src/nfa/tests-nfa.cc
+++ b/src/nfa/tests-nfa.cc
@@ -1738,3 +1738,82 @@ TEST_CASE("Vata2::Nfa::is_prfx_in_lang()")
 		REQUIRE(!is_prfx_in_lang(aut, w));
 	}
 } // }}}
+
+TEST_CASE("Vata2::Nfa::simulation()")
+{ // {{{
+    Nfa aut;
+
+    SECTION("empty automaton")
+    {
+        Vata2::Util::BinaryRelation result = compute_simulation(aut);
+
+        REQUIRE(result.size() == 0);
+    }
+
+    aut.increase_size(9);
+    SECTION("no-transition automaton")
+    {
+        aut.add_initial(1);
+        aut.add_initial(3);
+
+        aut.add_final(2);
+        aut.add_final(5);
+
+        Vata2::Util::BinaryRelation result = compute_simulation(aut);
+        REQUIRE(result.get(1,3));
+        REQUIRE(result.get(2,5));
+        REQUIRE(!result.get(5,1));
+        REQUIRE(!result.get(2,3));
+    }
+
+    SECTION("small automaton")
+    {
+        aut.add_initial(1);
+        aut.add_final(2);
+        aut.add_trans(1, 'a', 4);
+        aut.add_trans(4, 'b', 5);
+        aut.add_trans(2, 'b', 5);
+        aut.add_trans(1, 'b', 4);
+
+        Vata2::Util::BinaryRelation result = compute_simulation(aut);
+        REQUIRE(result.get(4,1));
+        REQUIRE(!result.get(2,5));
+
+    }
+
+    Nfa aut_big(9);
+
+    SECTION("bigger automaton")
+    {
+        aut_big.initialstates = {1,2};
+        aut_big.add_trans(1, 'a', 2);
+        aut_big.add_trans(1, 'a', 3);
+        aut_big.add_trans(1, 'b', 4);
+        aut_big.add_trans(2, 'a', 2);
+        aut_big.add_trans(2, 'b', 2);
+        aut_big.add_trans(2, 'a', 3);
+        aut_big.add_trans(2, 'b', 4);
+        aut_big.add_trans(3, 'b', 4);
+        aut_big.add_trans(3, 'c', 7);
+        aut_big.add_trans(3, 'b', 2);
+        aut_big.add_trans(5, 'c', 3);
+        aut_big.add_trans(7, 'a', 8);
+        aut_big.finalstates = {3};
+
+        Vata2::Util::BinaryRelation result = compute_simulation(aut_big);
+        REQUIRE(result.get(1,2));
+        REQUIRE(!result.get(2,1));
+        REQUIRE(!result.get(3,1));
+        REQUIRE(!result.get(3,2));
+        REQUIRE(result.get(4,1));
+        REQUIRE(result.get(4,2));
+        REQUIRE(result.get(4,5));
+        REQUIRE(!result.get(5,2));
+        REQUIRE(!result.get(5,1));
+        REQUIRE(result.get(7,1));
+        REQUIRE(result.get(7,2));
+        REQUIRE(result.get(8,1));
+        REQUIRE(result.get(8,2));
+        REQUIRE(result.get(8,5));
+    }
+} // }}

--- a/src/nfa/tests-nfa.cc
+++ b/src/nfa/tests-nfa.cc
@@ -1739,7 +1739,7 @@ TEST_CASE("Vata2::Nfa::is_prfx_in_lang()")
 	}
 } // }}}
 
-TEST_CASE("Vata2::Nfa::simulation()")
+TEST_CASE("Vata2::Nfa::fw-direct-simulation()")
 { // {{{
     Nfa aut;
 

--- a/src/nfa/tests-nfa.cc
+++ b/src/nfa/tests-nfa.cc
@@ -1745,7 +1745,7 @@ TEST_CASE("Vata2::Nfa::simulation()")
 
     SECTION("empty automaton")
     {
-        Vata2::Util::BinaryRelation result = compute_simulation(aut);
+        Vata2::Util::BinaryRelation result = compute_relation(aut);
 
         REQUIRE(result.size() == 0);
     }
@@ -1759,7 +1759,7 @@ TEST_CASE("Vata2::Nfa::simulation()")
         aut.add_final(2);
         aut.add_final(5);
 
-        Vata2::Util::BinaryRelation result = compute_simulation(aut);
+        Vata2::Util::BinaryRelation result = compute_relation(aut);
         REQUIRE(result.get(1,3));
         REQUIRE(result.get(2,5));
         REQUIRE(!result.get(5,1));
@@ -1775,7 +1775,7 @@ TEST_CASE("Vata2::Nfa::simulation()")
         aut.add_trans(2, 'b', 5);
         aut.add_trans(1, 'b', 4);
 
-        Vata2::Util::BinaryRelation result = compute_simulation(aut);
+        Vata2::Util::BinaryRelation result = compute_relation(aut);
         REQUIRE(result.get(4,1));
         REQUIRE(!result.get(2,5));
 
@@ -1800,7 +1800,7 @@ TEST_CASE("Vata2::Nfa::simulation()")
         aut_big.add_trans(7, 'a', 8);
         aut_big.finalstates = {3};
 
-        Vata2::Util::BinaryRelation result = compute_simulation(aut_big);
+        Vata2::Util::BinaryRelation result = compute_relation(aut_big);
         REQUIRE(result.get(1,2));
         REQUIRE(!result.get(2,1));
         REQUIRE(!result.get(3,1));


### PR DESCRIPTION
This pull request:

-  Imports computation of simulation from the original VATA library
-  Imports the related classes
-  Is based on migration of simulation to the previous library by Juraj.
-  Implements tests for simulation
-  Fixes issues reported by clang-tide and cppcheck
-  Changes names of functions from camel style to snake style
