### PR TITLE
Get shortest strings for NFA

### DIFF
--- a/src/nfa/tests-nfa.cc
+++ b/src/nfa/tests-nfa.cc
@@ -1843,3 +1843,84 @@ TEST_CASE("Vata2::Nfa::union_norename()") {
         REQUIRE(is_in_lang(result, zero));
     }
 }
+
+TEST_CASE("Vata2::Nfa::get_shortest_words()")
+{
+    Nfa aut('q' + 1);
+
+    SECTION("Automaton B")
+    {
+        FILL_WITH_AUT_B(aut);
+        Word word{};
+        word.push_back('b');
+        word.push_back('a');
+        std::set<Word> expected{word};
+        Word word2{};
+        word2.push_back('a');
+        word2.push_back('a');
+        expected.insert(expected.begin(), word2);
+        REQUIRE(aut.get_shortest_words() == expected);
+
+        SECTION("Additional initial state with longer words")
+        {
+            aut.initialstates.push_back(8);
+            REQUIRE(aut.get_shortest_words() == expected);
+        }
+
+        SECTION("Change initial state")
+        {
+			aut.initialstates.clear();
+            aut.initialstates.push_back(8);
+
+            word.clear();
+            word.push_back('b');
+            word.push_back('b');
+            word.push_back('a');
+            expected = std::set<Word>{word};
+            word2.clear();
+            word2.push_back('b');
+            word2.push_back('a');
+            word2.push_back('a');
+            expected.insert(expected.begin(), word2);
+
+            REQUIRE(aut.get_shortest_words() == expected);
+        }
+    }
+
+    SECTION("Empty automaton")
+    {
+        REQUIRE(aut.get_shortest_words().empty());
+    }
+
+    SECTION("Automaton A")
+    {
+        FILL_WITH_AUT_A(aut);
+        Word word{};
+        word.push_back('b');
+        word.push_back('a');
+        std::set<Word> expected{word};
+        Word word2{};
+        word2.push_back('a');
+        word2.push_back('a');
+        expected.insert(expected.begin(), word2);
+        REQUIRE(aut.get_shortest_words() == expected);
+    }
+
+    SECTION("Single transition automaton")
+    {
+        aut.initialstates = { 1 };
+        aut.finalstates = { 2 };
+        aut.add_trans(1, 'a', 2);
+
+        REQUIRE(aut.get_shortest_words() == std::set<Word>{Word{'a'}});
+    }
+
+    SECTION("Single state automaton")
+    {
+        aut.initialstates = { 1 };
+        aut.finalstates = { 1 };
+        aut.add_trans(1, 'a', 1);
+
+        REQUIRE(aut.get_shortest_words() == std::set<Word>{Word{}});
+    }
+}


### PR DESCRIPTION
This PR implements a method `get_shortest_strings()` for NFAs to get the shortest strings accepted by the NFA.

The PR contains:
1. An implementation of the method `get_shortest_strings()`,
2. Unit tests for the implemented method.

The method is a reimplementation of `get_shortest_strings_bfs()` function from [Python Noodler project](https://github.com/vhavlena/Noodler/blob/d533ee679ceceeae0ed7f9eb1de5a7fd925eaf9c/noodler/algos.py#L58) which computes the shortest strings using a BFS approach which is faster than the [previous approach](https://github.com/vhavlena/Noodler/blob/d533ee679ceceeae0ed7f9eb1de5a7fd925eaf9c/noodler/algos.py#L110).

For the sake of clarity and cleaner code, the method is split into several smaller functions. If we want to keep the method as a single function without splitting, I can remove the latest commit 3819bed5912cd95a82c84a2d57d1763ddcfb1dea. Otherwise, I will just squash both commits into one.

In the library, we already use a term *word* instead of a *string* in numerous places. Namely, we define a vector of symbols as a word:
```c++
using Word = std::vector<Symbol>;       /// a finite-length word
```
Other times, we use *string* again. Should we unify these terms and use only one of them? If so, we would need to rename *get_shortest_strings()* accordingly to respect the naming convention.

Sadly, as there is no parser and no converter between Python Awali representation and our C++ representation of automata, I cannot measure performance of `get_shortest_strings()` in comparison to its Python analogous function.

A future work before opening this PR includes writing more unit tests and (optionally) comparing time complexity requirements of both Python and C++ implementations, if the parser is implemented.

Also, there are multiple formatting conventions regarding brackets already in use in the library. Should we put curly brackets on a new line or keep them at the previous line? I am putting them on the new line so far as it appears to be more frequent. However, it would be nice to set these formatting conventions universally for all source files and follow them accordingly.